### PR TITLE
Adds new preferences for displaying custom logos

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -1197,6 +1197,8 @@ class ApiController(RedditController):
                    sponsor_name =VLength('sponsorship-name', max_length = 500),
                    sponsor_url = VLength('sponsorship-url', max_length = 500),
                    css_on_cname = VBoolean("css_on_cname"),
+                   logo_on_cname = VBoolean("logo_on_cname"),
+                   couple_looks = VBoolean("couple_looks"),
                    )
     def POST_site_admin(self, form, jquery, name, ip, sr,
                         sponsor_text, sponsor_url, sponsor_name,  **kw):
@@ -1207,8 +1209,8 @@ class ApiController(RedditController):
         kw = dict((k, v) for k, v in kw.iteritems()
                   if k in ('name', 'title', 'domain', 'description', 'over_18',
                            'show_media', 'type', 'link_type', 'lang',
-                           "css_on_cname", "header_title", 
-                           'allow_top'))
+                           "css_on_cname", "logo_on_cname", "couple_looks",
+                           "header_title", 'allow_top',))
 
         #if a user is banned, return rate-limit errors
         if c.user._spam:
@@ -1267,6 +1269,7 @@ class ApiController(RedditController):
 
             if not sr.domain:
                 del kw['css_on_cname']
+                del kw['logo_on_cname']
             for k, v in kw.iteritems():
                 setattr(sr, k, v)
             sr._commit()

--- a/r2/r2/controllers/embed.py
+++ b/r2/r2/controllers/embed.py
@@ -32,6 +32,7 @@ from urllib2 import HTTPError
 
 class EmbedController(RedditController):
     allow_stylesheets = True
+    allow_logo = True
 
     def rendercontent(self, input, fp):
         soup = BeautifulSoup(input)

--- a/r2/r2/controllers/front.py
+++ b/r2/r2/controllers/front.py
@@ -53,6 +53,7 @@ from urllib import quote_plus
 class FrontController(RedditController):
 
     allow_stylesheets = True
+    allow_logo = True
 
     @validate(article = VLink('article'),
               comment = VCommentID('comment'))

--- a/r2/r2/controllers/listingcontroller.py
+++ b/r2/r2/controllers/listingcontroller.py
@@ -59,6 +59,9 @@ class ListingController(RedditController):
     # allow stylesheets on listings
     allow_stylesheets = True
 
+    # allow logo on listings
+    allow_logo = True
+
     # toggles showing numbers 
     show_nums = True
 
@@ -591,6 +594,7 @@ class MessageController(ListingController):
     show_nums = False
     render_cls = MessagePage
     allow_stylesheets = False
+    allow_logo = False
 
     @property
     def menus(self):

--- a/r2/r2/controllers/post.py
+++ b/r2/r2/controllers/post.py
@@ -88,6 +88,7 @@ class PostController(ApiController):
               pref_num_comments = VInt('num_comments', 1, g.max_comments,
                                        default = g.num_comments),
               pref_show_stylesheets = VBoolean('show_stylesheets'),
+              pref_show_logos = VBoolean('show_logos'),
               pref_no_profanity = VBoolean('no_profanity'),
               pref_label_nsfw = VBoolean('label_nsfw'),
               pref_show_promote = VBoolean('show_promote'),

--- a/r2/r2/controllers/reddit_base.py
+++ b/r2/r2/controllers/reddit_base.py
@@ -473,6 +473,7 @@ def base_listing(fn):
 class MinimalController(BaseController):
 
     allow_stylesheets = False
+    allow_logo = False
 
     def request_key(self):
         # note that this references the cookie at request time, not
@@ -754,14 +755,31 @@ class RedditController(MinimalController):
 
         #check whether to allow custom styles
         c.allow_styles = self.allow_stylesheets
+        # check whether to allow custom logo
+        c.allow_logo = self.allow_logo
+
         if g.css_killswitch:
             c.allow_styles = False
-        #if the preference is set and we're not at a cname
-        elif not c.user.pref_show_stylesheets and not c.cname:
-            c.allow_styles = False
-        #if the site has a cname, but we're not using it
-        elif c.site.domain and c.site.css_on_cname and not c.cname:
-            c.allow_styles = False
+            c.allow_logo = False
+        else:
+            #if the preference is set and we're not at a cname
+            if not c.user.pref_show_stylesheets and not c.cname:
+                c.allow_styles = False
+            #if the site has a cname, but we're not using it
+            elif c.site.domain and c.site.css_on_cname and not c.cname:
+                c.allow_styles = False
+
+            #if the preference is set and we're not at a cname
+            if not c.user.pref_show_logos and not c.cname:
+                c.allow_logo = False
+            #if the site has a cname, but we're not using it
+            elif c.site.domain and c.site.logo_on_cname and not c.cname:
+                c.allow_logo = False
+
+            #if the style/logo are inseparable and one is disabled, both are
+            if c.couple_looks and not c.allow_styles or not c.allow_logo:
+                c.allow_logo = False
+                c.allow_styles = False
 
     def check_modified(self, thing, action,
                        private=True, max_age=0, must_revalidate=True):

--- a/r2/r2/controllers/toolbar.py
+++ b/r2/r2/controllers/toolbar.py
@@ -77,6 +77,7 @@ def auto_expand_panel(link):
 class ToolbarController(RedditController):
 
     allow_stylesheets = True
+    allow_logo = True
 
     @validate(link1 = VByName('id'),
               link2 = VLink('id', redirect = False))

--- a/r2/r2/models/account.py
+++ b/r2/r2/models/account.py
@@ -62,6 +62,7 @@ class Account(Thing):
                      pref_no_profanity = True,
                      pref_label_nsfw = True,
                      pref_show_stylesheets = True,
+                     pref_show_logos = True,
                      pref_mark_messages_read = True,
                      pref_threaded_messages = True,
                      pref_collapse_read_messages = False,

--- a/r2/r2/models/subreddit.py
+++ b/r2/r2/models/subreddit.py
@@ -59,6 +59,8 @@ class Subreddit(Thing, Printable):
                      valid_votes = 0,
                      show_media = False,
                      css_on_cname = True,
+                     logo_on_cname = True,
+                     couple_looks = False,
                      domain = None,
                      over_18 = False,
                      mod_actions = 0,

--- a/r2/r2/templates/createsubreddit.html
+++ b/r2/r2/templates/createsubreddit.html
@@ -189,12 +189,24 @@ function update_title(elem) {
   <%utils:line_field title="${_('domain')}" css_class="usertext">
     <div class="delete-field">
       %if thing.site and c.site.domain:
+      <ul>
+        <li>
           <input class="nomargin" type="checkbox" 
                  name="css_on_cname" id="css_on_cname"
                  ${thing.site.css_on_cname and "checked='checked'" or ""}/>
           <label for="css_on_cname">
             ${_("make custom CSS styles apply only when accessed from the cname.")}
           </label>
+        </li>
+        <li>
+          <input class="nomargin" type="checkbox" 
+                 name="logo_on_cname" id="logo_on_cname"
+                 ${thing.site.logo_on_cname and "checked='checked'" or ""}/>
+          <label for="logo_on_cname">
+            ${_("make custom logo apply only when accessed from the cname.")}
+          </label>
+        </li>
+      </ul>
       %endif
     </div>
     <div class="usertext-edit">
@@ -230,6 +242,14 @@ function update_title(elem) {
           <input type="text" name="header-title" id="header-title"
                  value="${thing.site.header_title}"
                  />
+        </li>
+        <li>
+          <input class="nomargin" type="checkbox" 
+                 name="couple_looks" id="couple_looks"
+                 ${(thing.site.couple_looks) and "checked='checked'" or ""}/>
+          <label for="couple_looks">
+            ${_("only show custom logo and custom style together.")
+          </label>
         </li>
         <li>
           <%utils:image_upload post_target="/api/upload_sr_img" 

--- a/r2/r2/templates/prefoptions.html
+++ b/r2/r2/templates/prefoptions.html
@@ -224,6 +224,7 @@
     <th>${_("display options")}</th>
     <td class="prefright">
       ${checkbox(_("allow reddits to show me custom styles"), "show_stylesheets")}
+      ${checkbox(_("allow reddits to show me custom logos"), "show_logos")}
     %if c.user.pref_show_promote is not None:
       <br/>
       ${checkbox(_("show promote tab on front page"), 

--- a/r2/r2/templates/redditheader.html
+++ b/r2/r2/templates/redditheader.html
@@ -34,7 +34,7 @@
   <div id="header-bottom-${'right' if c.lang_rtl else 'left'}">
     <%
         header_title = c.site.header_title
-        if c.site.header and c.allow_styles:
+        if c.site.header and c.allow_logo:
             header_img = c.site.header
         else:
             d = DefaultSR()


### PR DESCRIPTION
There are three new preferences in this change:  
1. User preference to show/hide custom logos in reddits, separating that behavior from the show/hide custom styles preference.  
   This is the main goal of the change, while the following two are meant to help reddit managers ensure that the look/feel of their reddits are maintained with this change.  
2. Reddit manager preference to only show the logo when the reddit is accessed through its CNAME (implemented as the existing preference for styles on CNAME).  
3. Reddit manager preference to make the style and logo either both show or hide (so that if the logo is heavily styled to fit with the stylesheet, it won't make things ugly).  

Thanks.
