### PR TITLE
Embed YouTube videos without Flash when possible

### DIFF
--- a/r2/r2/lib/scraper.py
+++ b/r2/r2/lib/scraper.py
@@ -337,7 +337,8 @@ class YoutubeScraper(MediaScraper):
     domains = ['youtube.com']
     height = 295
     width = 480
-    media_template = '<object width="490" height="295"><param name="movie" value="http://www.youtube.com/v/$video_id&fs=1"></param><param name="wmode" value="transparent"></param><param name="allowFullScreen" value="true"></param><embed src="http://www.youtube.com/v/$video_id&fs=1" type="application/x-shockwave-flash" wmode="transparent" allowFullScreen="true" width="480" height="295"></embed></object>'
+    media_template = '<iframe class="youtube-player" type="text/html" width="490" height="295" src="http://www.youtube.com/embed/$video_id" frameborder="0"></iframe>'
+
     thumbnail_template = 'http://img.youtube.com/vi/$video_id/default.jpg'
     video_id_rx = re.compile('.*v=([A-Za-z0-9-_]+).*')
     video_deeplink_rx = re.compile('.*#t=(\d+)m(\d+)s.*')


### PR DESCRIPTION
See http://apiblog.youtube.com/2010/07/new-way-to-embed-youtube-videos.html

This embeds videos in an iframe and falls back to flash when needed.
