### PR TITLE
registration popup scrolling allowed

### DIFF
--- a/r2/r2/public/static/css/reddit.css
+++ b/r2/r2/public/static/css/reddit.css
@@ -1501,7 +1501,7 @@ textarea.gray { color: gray; }
 }
 
 .popup {
-    position: fixed;
+    position: absolute;
     left: 10%;
     background-color: white;
     top: 40px;


### PR DESCRIPTION
on reddit.css: 

.popup { position: fixed; } changed to .popup { position: absolute; } to allow scrolling on the registration popup. This is especially helpful for those on netbooks and other small screens. 
