### PR TITLE
Added id to the label for limit search results to a subreddit

### DIFF
--- a/r2/r2/templates/searchform.html
+++ b/r2/r2/templates/searchform.html
@@ -38,7 +38,7 @@
       <input type="hidden" name="restrict_sr" value="off" />
     %else:
       <br /><br />
-      <input type="checkbox" ${'checked="checked"' if thing.restrict_sr else ''} name="restrict_sr" />
+      <input type="checkbox" ${'checked="checked"' if thing.restrict_sr else ''} name="restrict_sr" id="restrict_sr" />
       <label for="restrict_sr">${_('limit my search to %(path)s') % dict(path=thing.site.path.rstrip('/'))}</label>
       <br /><br />
     %endif


### PR DESCRIPTION
The [search page](http://www.reddit.com/r/redditdev/search?q=reddit) has a checkbox to limit search results to the selected subreddit.
The label for the checkbox had a _for_ attribute, but the checkbox itself didn't have an id. I added it so that click on the text next to the label checks or un-checks the checkbox.
