### PR TITLE
Disabling the reddit toolbar on mobile view

### DIFF
--- a/r2/r2/templates/link.compact
+++ b/r2/r2/templates/link.compact
@@ -60,7 +60,7 @@
      %if thing.is_self:
       <a href="${add_sr(thing.href_url)}">${thing.title}</a>
      %else:
-      <a href="${thing.tblink}.compact">${thing.title}</a>
+      <a href="${thing.href_url}">${thing.title}</a>
      %endif
     </p>
     %if thing.link_child and not c.permalink_page and thing.link_child.css_style.strip(' ') != 'video':


### PR DESCRIPTION
when viewing from mobile, the reddit toolbar is shown regardless of your preference settings.  the big problem with this toolbar is it displays unusually small, making it very difficult to click the "x" button on it.  this essentially breaks following any links on mobile unless you click on the thumbnail image.  if a thumbnail image isnt provided, you have no choice but to click on the toolbar infested link.  My change removes the toolbar link in favor of a direct link to the content.
