### PR TITLE
Add canonical shorturls to the header.

### DIFF
--- a/r2/r2/templates/base.compact
+++ b/r2/r2/templates/base.compact
@@ -31,6 +31,7 @@
     <link rel="apple-touch-startup-image" 
           href="/static/compact/reddit_startimg.png" />
     <link rel="canonical" href="${thing.canonical_link}" />
+    <link rel="shorturl" href="${thing.a.shortlink}" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;"/>
     <title>${self.Title()}</title>

--- a/r2/r2/templates/reddit.html
+++ b/r2/r2/templates/reddit.html
@@ -61,6 +61,9 @@
             type="text/css" />
       %endif
   %endif
+  %if thing.a.shortlink:
+    <link rel="shorturl" href="${thing.a.shortlink}"/>
+  %endif
 
   %if c.allow_styles and c.site.stylesheet_contents:
      <% inline_stylesheet = (


### PR DESCRIPTION
By adding `<link rel="shorturl" href="..."/>` to the header of the document, you can expose the canonical shorturl (`redd.it/`) to consumers (like [this Firefox addon](https://github.com/fwenzel/copy-shorturl)) so they use it instead of generating their own (e.g. with bit.ly).

I can't get Cassandra running locally and haven't been able to really test this out. It's a pretty small patch--even if this is not the way to do it--but it's a useful and low-cost feature.
