### PR TITLE
reverse title/text or title/url to make title smarter

### DIFF
--- a/r2/r2/templates/newlink.html
+++ b/r2/r2/templates/newlink.html
@@ -55,14 +55,6 @@ ${thing.formtabs_menu}
     %endif
 </div>
 
-<div class="spacer">
-  <%utils:round_field title="${_('title')}" id="title-field">
-    <textarea name="title" rows="2" cols="1" wrap="hard">${thing.title}</textarea>
-    ${error_field("NO_TEXT", "title", "div")}
-    ${error_field("TOO_LONG", "title", "div")}
-  </%utils:round_field>
-</div>
-
 %if thing.show_link:
 <div class="spacer">
   <%utils:round_field title="${_('url')}" id="url-field">
@@ -93,6 +85,14 @@ ${thing.formtabs_menu}
   </%utils:round_field>
 </div>
 %endif
+
+<div class="spacer">
+  <%utils:round_field title="${_('title')}" id="title-field">
+    <textarea name="title" rows="2" cols="1" wrap="hard">${thing.title}</textarea>
+    ${error_field("NO_TEXT", "title", "div")}
+    ${error_field("TOO_LONG", "title", "div")}
+  </%utils:round_field>
+</div>
 
 <div class="spacer">
   <%utils:round_field title="${_('reddit')}" id="reddit-field">


### PR DESCRIPTION
This is an attempt at mild social engineering to make Reddit better by making
titles more intentional.

Putting the title after the body of self-post should make people consider the
title as a summary instead of as a first line in a message.  After they type
the text, they've fully explored what they want to say, and are in a better
position to give a name to what they had in mind.

For instance, "Hey /r/android, I got my first Android phone the other day
(Nexus S) and I have a question" should be "How can I send SMS longer than 160
characters?", but the user treated the first field as the place to put the
first sentence of his "letter" to us, none of which is relevant.
