### PR TITLE
Hint the user that reporting is not the same as downvoting.

### DIFF
--- a/r2/r2/templates/printablebuttons.html
+++ b/r2/r2/templates/printablebuttons.html
@@ -57,7 +57,7 @@
   %elif thing.show_report:
     <li>
       ${ynbutton(_("report"), _("reported"), "report", "hide_thing",
-          _("downvote if you disagree! are you sure?"))}
+          _("report guideline violations only! are you sure?"))}
     </li>
   %endif
   %if thing.show_marknsfw:


### PR DESCRIPTION
When you click "report" on a _thing_ (comment/submission), you now get something more elaborate than "are you sure?". To avoid people mistaking the report feature as another way to downvote submissions and comments, they are asked to downvote them to express their disagreement instead of cluttering the modqueues with useless reports ("downvote if you disagree! are you sure?").

**This is untested!** Sorry, but at the moment, I can't be bothered to install and configure all of the many dependencies that reddit needs in order to work. I'm pretty optimistic that this one-line change won't break anything, though.
