### PR TITLE
Moderators of rather than to

### DIFF
--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -2580,7 +2580,7 @@ class ModList(UserList):
 
     @property
     def table_title(self):
-        return _("moderators to %(reddit)s") % dict(reddit = c.site.name)
+        return _("moderators of %(reddit)s") % dict(reddit = c.site.name)
 
     def editable_fn(self, user):
         if not c.user_is_loggedin:


### PR DESCRIPTION
I think that saying that these are the moderators _of_ a subreddit makes more sense than moderators _to_ a subreddit. 

I know it's a minor change, but this is my first open source contribution ever, so I just wanted to make sure I'm doing everything right.
