### PR TITLE
link literal subreddits in comments e.g. /r/canada

### DIFF
--- a/r2/r2/lib/py_markdown.py
+++ b/r2/r2/lib/py_markdown.py
@@ -8,6 +8,7 @@ href_re = re.compile('<a href="([^"]+)"', re.I)
 code_re = re.compile('<code>([^<]+)</code>')
 a_re    = re.compile('>([^<]+)</a>')
 fix_url = re.compile('&lt;(http://[^\s\'\"\]\)]+)&gt;')
+sr_link_re = re.compile(r'((?:^|\s)/?(r/[A-Za-z0-9][A-Za-z0-9_]{2,20}))')
 
 def code_handler(m):
     l = m.group(1)
@@ -55,5 +56,8 @@ def py_markdown(text, nofollow=False, target=None):
     text = code_re.sub(code_handler, text)
     text = a_re.sub(inner_a_handler, text)
     text = fix_url.sub(r'\1', text)
+
+    # link literal subreddits
+    text = sr_link_re.sub(r'<a href="/\2">\1</a>', text)
 
     return text


### PR DESCRIPTION
I think it's time to pave the /r/subreddit cow path. Lots of redditors use this convention so we may as well link it automatically. I thought I'd open the discussion with a patch. The regex is fairly conservative about what it matches but may need to be tweaked. I'm second guessing making the initial / optional, don't think I've seen that in the wild.

What do you guys think about this?
