### PR TITLE
Markdown: Allow the irc:// URL scheme (enables autolinking as well)

### DIFF
--- a/r2/r2/lib/contrib/discount/generate.c
+++ b/r2/r2/lib/contrib/discount/generate.c
@@ -409,6 +409,7 @@ static struct _protocol {
     _aprotocol( "http://" ), 
     _aprotocol( "news://" ),
     _aprotocol( "ftp://" ), 
+    _aprotocol( "irc://" ),
 #undef _aprotocol
 };
 #define NRPROTOCOLS	(sizeof protocol / sizeof protocol[0])


### PR DESCRIPTION
Currently, it's not possible to create hyperlinks from irc:// URLs on reddit; such URLs are not autolinked either. This patch changes this behaviour and adds irc:// to libdiscount's list of "safe" protocols.

I can't think of any new security issues that allowing the irc:// scheme could introduce -- if there are any, they should apply to schemes like http://, https:// or news:// as well.
