### PR TITLE
"Suggest Title" functionality for HTTPS sites

### DIFF
--- a/r2/r2/lib/utils/utils.py
+++ b/r2/r2/lib/utils/utils.py
@@ -233,7 +233,7 @@ def path_component(s):
 def get_title(url):
     """Fetches the contents of url and extracts (and utf-8 encodes)
        the contents of <title>"""
-    if not url or not url.startswith('http://'):
+    if not url or not (url.startswith('http://') or url.startswith('https://')):
         return None
 
     try:


### PR DESCRIPTION
I recently noticed that when I tried to submit a link to an HTTPS site, the "suggest title" button would always fail. Looking in the code, I ran across an if statement in the <tt>get_title</tt> function that required the URL start with <tt>http://</tt>. My patch updates the if statement to also allows <tt>https://</tt>.

A few things worth noting:
1. I haven't looked at the code much before and I haven't actually tested this patch. It's possible that there's other code preventing "suggest title" from working for HTTPS URLs. So fair warning. ;-)
2. The request uses <tt>urllib2</tt>. HTTPS requests made using that library don't validate certificates. Given the nature of the feature in question though, that doesn't seem like a terrible tradeoff.
