### PR TITLE
buttons.js patch

### DIFF
--- a/r2/r2/public/static/js/blogbutton.js
+++ b/r2/r2/public/static/js/blogbutton.js
@@ -139,8 +139,8 @@ $(function() {
             $(".bling a, a.bling").attr("href", submit);
             $(".arrow").each(function() {
                     $(this).get(0).onclick = function() {
-                        if(target == '_blank'){
-                            window.open(submit, target);
+                        if(querydict.newwindow){
+                            window.open(submit, "_blank");
                         } else {
                             window.parent.location = submit;
                        }


### PR DESCRIPTION
At line 145 target is getting polluted with a url from some parent function.  Using the original querydict.newwindow should fix the uparrows to open in a new window when the option is set to true.
