### PR TITLE
Fix inconsistency between 'pageviews' and 'impressions' on the reddittraffic template

### DIFF
--- a/r2/r2/templates/reddittraffic.html
+++ b/r2/r2/templates/reddittraffic.html
@@ -114,10 +114,10 @@ ${unsafe(js.use('flot'))}
 </p>
 <ul style="margin:7px">
   <li>
-    <b>pageviews</b> &#32;are all hits to ${c.site.name}, including both listing pages and comment pages.
+    <b>impressions</b> &#32;are all hits to ${c.site.name}, including both listing pages and comment pages.
   </li>
   <li>
-    <b>uniques</b> &#32;are the total number of unique visitors (IP and U/A combo) that generate the above pageviews. This is independent of whether or not they are logged in.
+    <b>uniques</b> &#32;are the total number of unique visitors (IP and U/A combo) that generate the above impressions. This is independent of whether or not they are logged in.
   </li>
   <li>
     <b>subscriptions</b> &#32;is the number of new subscriptions in a given day that have been generated. This number is less accurate than the first two metrics, as, though we can track new subscriptions, we have no way to track unsubscriptions (which are when a subscription is actually deleted from the db).


### PR DESCRIPTION
Updated reddittraffic template to define 'impressions' rather than 'pageviews' to reflect the terminology used on the charts.
