### PR TITLE
MoreCommentsJsonTemplate now lists children.

### DIFF
--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -369,11 +369,15 @@ class CommentJsonTemplate(ThingJsonTemplate):
 
 class MoreCommentJsonTemplate(CommentJsonTemplate):
     _data_attrs_ = dict(id           = "_id36",
-                        name         = "_fullname")
+                        name         = "_fullname",
+                        children     = "children")
+
     def kind(self, wrapped):
         return "more"
 
     def thing_attr(self, thing, attr):
+        if attr == 'children':
+            return [to36(x) for x in thing.children]
         if attr in ('body', 'body_html'):
             return ""
         return CommentJsonTemplate.thing_attr(self, thing, attr)


### PR DESCRIPTION
As the title says, the API should list the individual comments as an attribute "children". This patch should allow users of the reddit API to remove a number of hacks they may have written to fetch all the comments. I confirmed this works in a dev environment.
