### PR TITLE
Fix for issue #45

### DIFF
--- a/r2/r2/public/static/js/reddit.js
+++ b/r2/r2/public/static/js/reddit.js
@@ -885,11 +885,13 @@ function show_edit_usertext(form) {
         var new_width = Math.max(body_width - 5, textarea.width());
         textarea.width(new_width);
         edit.width(new_width);
-        edit.parent("form").width(new_width);
 
         var new_height = Math.max(body_height, textarea.height());
         textarea.height(new_height);
     }
+    
+    // Fix for issue #45
+    form.width(Math.max(body_width - 5, textarea.width()));
 
     form
         .find(".cancel, .save").show().end()


### PR DESCRIPTION
The issue for the problem #45 seems to be that the form was still taking 100% of the width of the page making everything under unclickable.

I have tested with Firefox and Chrome and it's working fine now with this patch. For the other browser, I haven't tested yet, because it's a little hard to test at the moment.
