### PR TITLE
clearflairtemplates errors when templates have never been set

### DIFF
--- a/r2/r2/models/flair.py
+++ b/r2/r2/models/flair.py
@@ -187,7 +187,7 @@ class FlairTemplateBySubredditIndex(tdb_cassandra.Thing):
             idx = cls.by_sr(sr_id)
         except tdb_cassandra.NotFound:
             # Everything went better than expected.
-            pass
+            return
 
         for k in idx._index_keys():
             del idx[k]


### PR DESCRIPTION
Attempting to clear flairtemplates for a subreddit which has never had templates set causes the following lookup to fail:

``` python
idx = cls.by_sr(sr_id)
```

I will also note that once setting a template, removing it and then attempting to clear when there are no templates doesn't have the same issue. Perhaps there is a better solution which results in an empty list rather than a failed db lookup.

Error:

``` python
File './r2/controllers/validator/validator.py', line 170 in newfn
  simple_vals, param_vals, *a, **kw)
File './r2/controllers/validator/validator.py', line 218 in validatedForm
  val = self_method(self, form, responder, *a, **kw)
File './r2/controllers/api.py', line 2115 in POST_clearflairtemplates
  FlairTemplateBySubredditIndex.clear(c.site._id)
File './r2/models/flair.py', line 192 in clear
  for k in idx._index_keys():
UnboundLocalError: local variable 'idx' referenced before assignment
```
