### PR TITLE
Prevent BAD_CAPTCHA error from occurring when captchas are disabled

### DIFF
--- a/r2/r2/controllers/validator/validator.py
+++ b/r2/r2/controllers/validator/validator.py
@@ -585,7 +585,7 @@ class VCaptcha(Validator):
     default_param = ('iden', 'captcha')
     
     def run(self, iden, solution):
-        if (not c.user_is_loggedin or c.user.needs_captcha()):
+        if c.user.needs_captcha():
             valid_captcha = captcha.valid_solution(iden, solution)
             if not valid_captcha:
                 self.set_error(errors.BAD_CAPTCHA)

--- a/r2/r2/models/account.py
+++ b/r2/r2/models/account.py
@@ -213,7 +213,7 @@ class Account(Thing):
         return id_time + ',' + sha.new(to_hash).hexdigest()
 
     def needs_captcha(self):
-        return self.link_karma < 1 and not g.disable_captcha
+        return not g.disable_captcha and self.link_karma < 1
 
     def modhash(self, rand=None, test=False):
         return modhash(self, rand = rand, test = test)


### PR DESCRIPTION
When running locally with captchas disabled, a bad captcha error is reported along with a successful user creation because the `g.disable_captcha` setting is only checked if the client is logged in. However, when creating a reddit account, there is no logged in user, thus this setting was previously ignored.
