### PR TITLE
Fix error.py's JSON api response: property name should be quoted.

### DIFF
--- a/r2/r2/controllers/error.py
+++ b/r2/r2/controllers/error.py
@@ -175,7 +175,7 @@ class ErrorController(RedditController):
                      c.response.content = str(code)
                 return c.response
             elif c.render_style == "api":
-                c.response.content = "{error: %s}" % code
+                c.response.content = "{\"error\": %s}" % code
                 return c.response
             elif takedown and code == 404:
                 link = Link._by_fullname(takedown)


### PR DESCRIPTION
`{error: 404}` should be `{"error": 404}`. Without the quotes, http://jsonlint.com produces the following validation error message:

```
Parse error on line 1:
{    error: 404}
-----^
Expecting 'STRING', '}'
```
