### PR TITLE
Fix reddit name ajax autocompletion (error 404) on new link submission page.

### DIFF
--- a/r2/r2/public/static/js/reddit.js
+++ b/r2/r2/public/static/js/reddit.js
@@ -703,7 +703,7 @@ function sr_search(query) {
     query = query.toLowerCase();
     var cache = sr_cache();
     if (!cache[query]) {
-        $.request('search_reddit_names', {query: query},
+        $.request('search_reddit_names.json', {query: query},
                   function (r) {
                       cache[query] = r['names'];
                       update_dropdown(r['names']);


### PR DESCRIPTION
The `search_reddit_names` API call requires the ".json" suffix. Currently, every call to `/api/search_reddit_names` returns a 404 error page.
