### PR TITLE
Address trivial semantic issue in "login or register" button

### DIFF
--- a/r2/r2/templates/redditheader.html
+++ b/r2/r2/templates/redditheader.html
@@ -69,7 +69,7 @@
           login_url = add_sr(base + "/login", sr_path=False)
         %>
         ${text_with_links(_("want to join? %(login_or_register)s in seconds"),
-            login_or_register = dict(link_text=_("login or register"), path=login_url, _class="login-required"))}
+            login_or_register = dict(link_text=_("login or register"), path=login_url))}
       </span>
       ${separator("|")}
       %endif


### PR DESCRIPTION
The `login-required` class prevents the "login or register" button from actually linking to `https://ssl.reddit.com/login`; instead, clicking the button pops up a window which says "you'll need to login or register to do that" (which, I find, doesn't make much sense, i.e., you don't have to login to login).

It seems the original intention (commit 087552494e6bd8c1b417c64d4bdbb8a8b67d6763) was indeed to link to the https page.
