### PR TITLE
Reddittraffic template should define 'pageviews' rather than 'impressions'.

### DIFF
--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -3164,7 +3164,7 @@ class RedditTraffic(Traffic):
                 break
             slices = [("uniques",     (0, 2) if c.site.domain else (0,),
                        "FF4500"),
-                      ("impressions", (1, 3) if c.site.domain else (1,),
+                      ("pageviews", (1, 3) if c.site.domain else (1,),
                        "336699")]
             if not c.default_sr and ival == 'day':
                 slices.append(("subscriptions", (4,), "00FF00"))

--- a/r2/r2/templates/reddittraffic.html
+++ b/r2/r2/templates/reddittraffic.html
@@ -47,14 +47,14 @@ ${unsafe(js.use('flot'))}
         </tr><tr>
           <th>${_("date")}</th>
           <th>${_("uniques")}</th>
-          <th>${_("impressions")}</th>
+          <th>${_("pageviews")}</th>
           <th>${_("uniques")}</th>
-          <th>${_("impressions")}</th>
+          <th>${_("pageviews")}</th>
           <th>${_("subscriptions")}</th>
         %else:
           <th>${_("date")}</th>
           <th>${_("uniques")}</th>
-          <th>${_("impressions")}</th>
+          <th>${_("pageviews")}</th>
           %if not c.default_sr:
             <th>${_("subscriptions")}</th>
           %endif
@@ -85,7 +85,7 @@ ${unsafe(js.use('flot'))}
       <tr>
         <th>${_("date")}</th>
         <th>${_("uniques")}</th>
-        <th>${_("impressions")}</th>
+        <th>${_("pageviews")}</th>
       </tr>
       <%
          dow = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", 
@@ -184,7 +184,7 @@ ${unsafe(js.use('flot'))}
         <tr>
           <th>${_("date")}</th>
           <th>${_("uniques")}</th>
-          <th>${_("impressions")}</th>
+          <th>${_("pageviews")}</th>
         </tr>
         %for i, d in enumerate(reversed(data)):
           <tr class="${'odd' if i % 2 else 'even'}">
@@ -203,9 +203,9 @@ ${unsafe(js.use('flot'))}
         <tr>
           <th>${_("date")}</th>
           <th>${_("uniques")}</th>
-          <th>${_("impressions")}</th>
+          <th>${_("pageviews")}</th>
           <th>${_("uniques")}</th>
-          <th>${_("impressions")}</th>
+          <th>${_("pageviews")}</th>
           <th>${_("cname")}</th>
         </tr>
         %for i, (sr, d) in enumerate(thing.reddits_summary()):


### PR DESCRIPTION
This change improve consistency.

Unnecessary extra info: this actually was my first Reddit source change. I neglected to re-add a _clean_ pull request for it until now.
