### PR TITLE
Fix for issue #264: JSON response for submission API now submission

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -337,6 +337,9 @@ class ApiController(RedditController):
         if extension:
             path += ".%s" % extension
         form.redirect(path)
+        form._send_data(url=path)
+        form._send_data(id=l._id36)
+        form._send_data(name=l._fullname)
 
     @validatedForm(VRatelimit(rate_ip = True,
                               rate_user = True,


### PR DESCRIPTION
Tested that this works as expected with api_type:json and the 302 redirect still occurs when using a web browser.

Fixes issue #264.
