### PR TITLE
Image upload will now give an error when failing

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -1225,7 +1225,7 @@ class ApiController(RedditController):
                 new_url = cssfilter.save_sr_image(c.site, file, suffix ='.' + img_type)
             except cssfilter.BadImage:
                 errors['IMAGE_ERROR'] = _("Invalid image or general image error")
-                return UploadedImage("", "", "", errors=errors).render()
+                return UploadedImage("", "", "", errors=errors, form_id=form_id).render()
             size = str_to_image(file).size
             if header:
                 c.site.header = new_url


### PR DESCRIPTION
Fixes #212, as introduced in 2009 with bf9f43ccacc4ee7933629c621f97d6ff0ddd11b8
