### PR TITLE
Add option to make subreddit traffic stats page public

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -1263,6 +1263,7 @@ class ApiController(RedditController):
                    over_18 = VBoolean('over_18'),
                    allow_top = VBoolean('allow_top'),
                    show_media = VBoolean('show_media'),
+                   public_traffic = VBoolean('public_traffic'),
                    show_cname_sidebar = VBoolean('show_cname_sidebar'),
                    type = VOneOf('type', ('public', 'private', 'restricted', 'archived')),
                    link_type = VOneOf('link_type', ('any', 'link', 'self')),
@@ -1280,7 +1281,8 @@ class ApiController(RedditController):
         redir = False
         kw = dict((k, v) for k, v in kw.iteritems()
                   if k in ('name', 'title', 'domain', 'description', 'over_18',
-                           'show_media', 'show_cname_sidebar', 'type', 'link_type', 'lang',
+                           'show_media', 'public_traffic',
+                           'show_cname_sidebar', 'type', 'link_type', 'lang',
                            "css_on_cname", "header_title", 
                            'allow_top'))
 

--- a/r2/r2/controllers/front.py
+++ b/r2/r2/controllers/front.py
@@ -533,7 +533,7 @@ class FrontController(RedditController):
             pane = self._make_spamlisting(location, num, after, reverse, count)
             if c.user.pref_private_feeds:
                 extension_handling = "private"
-        elif is_moderator and location == 'traffic':
+        elif (c.site.public_traffic or is_moderator) and location == 'traffic':
             pane = RedditTraffic()
         elif is_moderator and location == 'flair':
             pane = FlairPane(num, after, reverse, name, user)

--- a/r2/r2/models/modaction.py
+++ b/r2/r2/models/modaction.py
@@ -65,6 +65,7 @@ class ModAction(tdb_cassandra.UuidThing, Printable):
                      'over_18': _('toggle viewers must be over 18'),
                      'allow_top': _('toggle allow in default set'),
                      'show_media': _('toggle show thumbnail images of content'),
+                     'public_traffic': _('toggle public traffic stats page'),
                      'domain': _('domain'),
                      'show_cname_sidebar': _('toggle show sidebar from cname'),
                      'css_on_cname': _('toggle custom CSS from cname'),

--- a/r2/r2/models/subreddit.py
+++ b/r2/r2/models/subreddit.py
@@ -76,6 +76,7 @@ class Subreddit(Thing, Printable):
                      flair_enabled = True,
                      flair_position = 'right', # one of ('left', 'right')
                      flair_self_assign_enabled = False,
+                     public_traffic = False,
                      )
     _essentials = ('type', 'name', 'lang')
     _data_int_props = Thing._data_int_props + ('mod_actions', 'reported')

--- a/r2/r2/templates/createsubreddit.html
+++ b/r2/r2/templates/createsubreddit.html
@@ -163,6 +163,14 @@
             ${_("show thumbnail images of content")}
           </label>
         </li>
+        <li>
+          <input class="nomargin" type="checkbox"
+                 name="public_traffic" id="public_traffic"
+                 ${thing.site and thing.site.public_traffic and "checked='checked'" or ""}/>
+          <label for="public_traffic">
+            ${_("make the traffic stats page available to everyone")}
+          </label>
+        </li>
       </ul>
     </div>
   </%utils:line_field>


### PR DESCRIPTION
Inspired by [pegasus_527](http://www.reddit.com/user/pegasus_527)'s post: [The option to make your subreddit's traffic stats publicly available](http://www.reddit.com/r/ideasfortheadmins/comments/nw7g5/the_option_to_make_your_subreddits_traffic_stats/)
