### PR TITLE
Allow "/by_id/<names>" to accept Subreddit id36 fullnames.

### DIFF
--- a/r2/r2/controllers/listingcontroller.py
+++ b/r2/r2/controllers/listingcontroller.py
@@ -460,11 +460,11 @@ class ByIDController(ListingController):
     def query(self):
         return self.names
 
-    @validate(links = VByName("names", thing_cls = Link, multiple = True))
-    def GET_listing(self, links, **env):
-        if not links:
+    @validate(things = VByName("names", thing_cls = (Link, Subreddit), multiple = True))
+    def GET_listing(self, things, **env):
+        if not things:
             return self.abort404()
-        self.names = [l._fullname for l in links]
+        self.names = [t._fullname for t in things]
         return ListingController.GET_listing(self, **env)
 
 

--- a/r2/r2/controllers/validator/validator.py
+++ b/r2/r2/controllers/validator/validator.py
@@ -529,7 +529,8 @@ class VAccountByName(VRequired):
 def fullname_regex(thing_cls = None, multiple = False):
     pattern = "[%s%s]" % (Relation._type_prefix, Thing._type_prefix)
     if thing_cls:
-        pattern += utils.to36(thing_cls._type_id)
+        type_ids = [utils.to36(c._type_id) for c in utils.tup(thing_cls)] 
+        pattern += '(%s)' % '|'.join(type_ids)
     else:
         pattern += r"[0-9a-z]+"
     pattern += r"_[0-9a-z]+"


### PR DESCRIPTION
The pull request modifies `/by_id/<names>` to accept Subreddit fullnames (instead of just Link fullnames). This lets the caller to query meta data about Subreddits (description, nsfw-ness, etc.).
