### PR TITLE
When api_type=json, return new captcha iden to caller when VCaptcha fails.

### DIFF
--- a/r2/r2/lib/jsonresponse.py
+++ b/r2/r2/lib/jsonresponse.py
@@ -70,6 +70,8 @@ class JsonResponse(object):
         res = {}
         if self._data:
             res['data'] = self._data
+        if self._new_captcha:
+            res['captcha'] = get_iden()
         res['errors'] = [(e[0], c.errors[e].message, e[1]) for e in self._errors]
         return {"json": res}
 
@@ -120,6 +122,9 @@ class JsonResponse(object):
 
     def _send_data(self, **kw):
         self._data.update(kw)
+
+    def new_captcha(self):
+        self._new_captcha = True
 
 
 class JQueryResponse(JsonResponse):


### PR DESCRIPTION
Currently, new captcha idens are only generated for the `JQueryResponse` format. This commit modifies `JsonResponse` to also include it when `api_type=json`.
