### PR TITLE
Modify /api/subscribe to allow subscribing subreddits by name with "sr_name".

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -1747,7 +1747,7 @@ class ApiController(RedditController):
     @noresponse(VUser(),
                 VModhash(),
                 action = VOneOf('action', ('sub', 'unsub')),
-                sr = VByName('sr'))
+                sr = VSubscribeSR('sr', 'sr_name'))
     def POST_subscribe(self, action, sr):
         # only users who can make edits are allowed to subscribe.
         # Anyone can leave.

--- a/r2/r2/controllers/validator/validator.py
+++ b/r2/r2/controllers/validator/validator.py
@@ -826,6 +826,24 @@ class VSubmitSR(Validator):
 
         return sr
 
+class VSubscribeSR(VByName):
+    def __init__(self, srid_param, srname_param):
+        VByName.__init__(self, (srid_param, srname_param)) 
+
+    def run(self, sr_id, sr_name):
+        if sr_id:
+            return VByName.run(self, sr_id)
+        elif not sr_name:
+            return
+
+        try:
+            sr = Subreddit._by_name(str(sr_name).strip())
+        except (NotFound, AttributeError, UnicodeEncodeError):
+            self.set_error(errors.SUBREDDIT_NOEXIST)
+            return
+
+        return sr
+
 MIN_PASSWORD_LENGTH = 3
 
 class VPassword(Validator):


### PR DESCRIPTION
This pull request modifies `/api/subscribe` to let the caller subscribe to a subreddit by name (e.g. "funny", "pics", etc) with the `sr_name` param (instead of just fullname with the `sr` param). The motivation behind this is so that callers don't need to find the fullname through other means (See [example](https://github.com/talklittle/reddit-is-fun/blob/master/src/com/andrewshu/android/reddit/common/Common.java#L540)).
