### PR TITLE
Modify /api/new_captcha to return "iden" when api_type=json.

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -82,7 +82,9 @@ class ApiminimalController(MinimalController):
 
     @validatedForm()
     def POST_new_captcha(self, form, jquery, *a, **kw):
-        jquery("body").captcha(get_iden())
+        iden = get_iden()
+        jquery("body").captcha(iden)
+        form._send_data(iden = iden) 
 
 
 class ApiController(RedditController):


### PR DESCRIPTION
Currently, calling `/api/new_captcha` with `api_type=json` does not yield any useful information. Because of this, the only way to grab the captcha iden is to make the call with `api_type=html`. This pull request modifies `/api/new_captcha` to return `iden` when `api_type=json`.
