### PR TITLE
Modify /api/submit to return QUOTA_FILLED error when api_type=json.

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -293,6 +293,7 @@ class ApiController(RedditController):
 
                 md = safemarkdown(msg)
                 form.set_html(".status", md)
+                form.send_failure(errors.QUOTA_FILLED)
                 return
 
         # well, nothing left to do but submit it

--- a/r2/r2/controllers/errors.py
+++ b/r2/r2/controllers/errors.py
@@ -60,6 +60,7 @@ error_list = dict((
         ('SUBREDDIT_REQUIRED', _('you must specify a subreddit')),
         ('BAD_SR_NAME', _('that name isn\'t going to work')),
         ('RATELIMIT', _('you are doing that too much. try again in %(time)s.')),
+        ('QUOTA_FILLED', _("You've submitted too many links recently. Please try again in an hour.")),
         ('EXPIRED', _('your session has expired')),
         ('DRACONIAN', _('you must accept the terms first')),
         ('BANNED_IP', "IP banned"),


### PR DESCRIPTION
Currently, when `api_type=json`, there's no way to tell whether `/api/submit` succeeded or failed due to reaching the Link quota limit. This pull request introduces a new error name, QUOTA_FILLED, that lets the caller know the exact reason.
