### PR TITLE
Fix issue #323

### DIFF
--- a/r2/r2/lib/utils/utils.py
+++ b/r2/r2/lib/utils/utils.py
@@ -255,7 +255,7 @@ def get_title(url):
         
         # Title not found in the first kb, try searching an additional 2kb
         if not title:
-			data += opener.read(2048)
+            data += opener.read(2048)
             title = extract_title(data)
         
         opener.close()


### PR DESCRIPTION
This extremely trivial (3 characters) change should fix issue #323

get_title was hard-coded to only use the first 1kb when finding a title. Unfortunately youtube has a ton of javascript before the title, so the title falls outside that first 1kb. get_title is now hard-coded to use the first 4kb.

hope I did this fork/pull request thing right... first time 'eh...
