### PR TITLE
Some attributes in new items not being marked as dirty

### DIFF
--- a/r2/r2/lib/db/thing.py
+++ b/r2/r2/lib/db/thing.py
@@ -109,7 +109,7 @@ class DataThing(object):
         else:
             old_val = self._t.get(attr, self._defaults.get(attr))
             self._t[attr] = val
-        if make_dirty and val != old_val:
+        if make_dirty and (val != old_val or not self._created):
             self._dirties[attr] = (old_val, val)
 
     def __getattr__(self, attr):


### PR DESCRIPTION
Attributes in items were not properly being marked as dirty if they had the same value as the their default.  Thus, over_18 was not being set and the listing was only showing items who actually had an under_18 value.  I am not sure why live is not experiencing this....
