### PR TITLE
Wrap the 'this post was submitted on' text in its own span.

### DIFF
--- a/r2/r2/templates/linkinfobar.html
+++ b/r2/r2/templates/linkinfobar.html
@@ -32,8 +32,10 @@
 
 <div class="linkinfo">
   <div class="date">
-    ${_("this post was submitted on")}
-    &#32;
+    <span>
+      ${_("this post was submitted on")}
+      &#32;
+    </span>
     <time datetime="${thing.a._date.isoformat()}">
       ${thing.a._date.strftime(thing.datefmt)}
     </time>


### PR DESCRIPTION
Alright, I finally got it so there isn't a dozen crappy commits of my own tagging along with this little change.  This would allow people to change the 'This post was submitted on' text to whatever they want with their subreddit's css.
