### PR TITLE
Fixed Issue #340: Comment RSS feed shows TZ twice

### DIFF
--- a/r2/r2/templates/comment.xml
+++ b/r2/r2/templates/comment.xml
@@ -41,7 +41,7 @@
   <guid isPermaLink="true">${permalink}</guid>
   <title>${author} ${_("on")} ${thing.link.title}</title>
   <link>${permalink}</link>
-  <dc:date>${thing._date.isoformat()}-0700</dc:date>
+  <dc:date>${thing._date.isoformat()}</dc:date>
   <description>${body|h}</description>
 </item>
 


### PR DESCRIPTION
Static TZ info was listed in the `<dc:date>` entry after the dynamic date info.
See #340 for more info
