### PR TITLE
Fix for issue #324

### DIFF
--- a/r2/r2/public/static/js/reddit.js
+++ b/r2/r2/public/static/js/reddit.js
@@ -929,9 +929,9 @@ function edit_usertext(elem) {
 }
 
 function cancel_usertext(elem) {
-    var t = $(elem).thing().debug();
-    t.find(".edit-usertext:first").parent("li").andSelf().show(); 
-    hide_edit_usertext(t.find(".usertext:first"));
+    var t = $(elem);
+    t.thing().find(".edit-usertext:first").parent("li").andSelf().show(); 
+    hide_edit_usertext(t.closest(".usertext"));
 }
 
 function save_usertext(elem) {


### PR DESCRIPTION
cancel_usertext() was hiding the first usertext item but when this was done on a child element after an edit was saved, it was finding the first hidden edit usertext item instead of itself. Changed it to find the closest usertext from the cancel button so it'll only hide itself, not the first if there are preceding ones.

Fix for issue #324. 
