### PR TITLE
Fixed issue #205

### DIFF
--- a/r2/r2/templates/messagecompose.html
+++ b/r2/r2/templates/messagecompose.html
@@ -39,7 +39,7 @@
 function admincheck(elem) {
   var admins = ${unsafe(simplejson.dumps(thing.admins))};
 
-  if (admins.indexOf(elem.value) >= 0) {
+  if ($.inArray(elem.value, admins) >= 0) {
     $(".admin-to").text(elem.value);
     $(".clippy").show();
   } else {


### PR DESCRIPTION
Now uses JQuery.inArray() instead of Array.indexOf() which IE7-8 did not implement. 
