### PR TITLE
Fix issue where child comment would get vote of parent if parent deleted

### DIFF
--- a/r2/r2/templates/thingupdater.html
+++ b/r2/r2/templates/thingupdater.html
@@ -6,10 +6,10 @@
   var dislikes = ${unsafe(simplejson.dumps(thing.dislikes))};
   var friends = ${unsafe(simplejson.dumps(list(thing.is_friend)))};
   $.map(likes, function(l) {
-            $(".id-" + l).find(".arrow.up:first").vote("", null, null, true);
+            $(".id-" + l + " > .midcol").find(".arrow.up").vote("", null, null, true);
         });
   $.map(dislikes, function(l) {
-            $(".id-" + l).find(".arrow.down:first").vote("", null, null, true);
+            $(".id-" + l + " > .midcol").find(".arrow.down").vote("", null, null, true);
         });
   $.map(friends, show_friend);
 


### PR DESCRIPTION
when the initial load was looking for like/dislike, it was using `:first` to find the `.arrow` class. this normally worked but if the parent comment was subsequently deleted, it would find the first child comment's `.arrow`. changed this to look for `.arrow` class within the `.midcol` of the parent instead of just blindly grabbing the first one.

fix for #193
