### PR TITLE
Restrict show_friends to only display [F] in div.content

### DIFF
--- a/r2/r2/public/static/js/reddit.js
+++ b/r2/r2/public/static/js/reddit.js
@@ -1242,7 +1242,7 @@ $(function() {
 
 function show_friend(account_fullname) {
     var label = '<a class="friend" title="friend" href="/prefs/friends">F</a>';
-    var ua = $(".author.id-" + account_fullname).addClass("friend")
+    var ua = $("div.content .author.id-" + account_fullname).addClass("friend")
         .next(".userattrs").each(function() {
                 if (!$(this).html()) {
                     $(this).html(" [" + label + "]");


### PR DESCRIPTION
show_friends was finding all instances of `.author` but friend should only show on comments/posts. set it to look in `div.content` to restrict location of authors to tag as friends

fix for #88
