### PR TITLE
Moved "sponsored link" text left to space it out from "what's this" link

### DIFF
--- a/r2/r2/public/static/css/reddit.css
+++ b/r2/r2/public/static/css/reddit.css
@@ -941,7 +941,7 @@ a.author { margin-right: 0.5em; }
 }
 
 .organic-listing .sponsored-tagline {
-    right: 6.4em;
+    right: 6.8em;
 }
 
 .sponsored-tagline {


### PR DESCRIPTION
increased `right` style to move sponsored link slightly away from "what's this" link on pcs

how it rendered on pcs before:

![https://camo.githubapp.com/53bba153812ffaef6fad195356391d9e928f5e25/687474703a2f2f692e696d6775722e636f6d2f35653664742e706e67](https://camo.githubapp.com/53bba153812ffaef6fad195356391d9e928f5e25/687474703a2f2f692e696d6775722e636f6d2f35653664742e706e67)

how it renders now:

mac:
![http://i.imgur.com/xnB32.png](http://i.imgur.com/xnB32.png)

pc:
![http://i.imgur.com/ixCmh.png](http://i.imgur.com/ixCmh.png)

fix for #386
