### PR TITLE
Removed a reference to deputy moderation 

### DIFF
--- a/r2/r2/i18n/r2.pot
+++ b/r2/r2/i18n/r2.pot
@@ -3613,8 +3613,7 @@ msgstr ""
 
 #: r2/templates/prefoptions.html:139
 msgid ""
-"(it shows new and promoted links, and gives you a say in what's spam and what"
-" isn't.)"
+"(it shows new and promoted links.)"
 msgstr ""
 
 #: r2/templates/prefoptions.html:143


### PR DESCRIPTION
In the preferences menu, I think this is referring to the deputy moderation from a couple of years ago: http://blog.reddit.com/2010/04/youve-been-drafted.html

The spotlight box doesn't show that any more.
