### PR TITLE
Add title attribute to flair span.

### DIFF
--- a/r2/r2/templates/flairselectorlinksample.html
+++ b/r2/r2/templates/flairselectorlinksample.html
@@ -21,7 +21,7 @@
 ################################################################################
 
 <%def name="flair()">
-  <span class="linkflairlabel">${thing.flair_text}</span>
+  <span class="linkflairlabel" title="${thing.flair_text}">${thing.flair_text}</span>
 </%def>
 
 <div class="linkflair ${' '.join('linkflair-%s' % c for c in thing.flair_css_class.split())}">

--- a/r2/r2/templates/wrappeduser.html
+++ b/r2/r2/templates/wrappeduser.html
@@ -27,7 +27,7 @@
     <% enabled = user.flair_enabled %>
   %endif
   %if user.has_flair and enabled:
-    <span class="flair ${user.flair_css_class}">${user.flair_text}</span>
+    <span class="flair ${user.flair_css_class}" title="${user.flair_text}">${user.flair_text}</span>
   %endif
 </%def>
 


### PR DESCRIPTION
This allows the full text to be discovered when the item is too long for the entire span to be shown. This hiding most often occurs in the flair selector.
