### PR TITLE
Fix for issue #233

### DIFF
--- a/r2/r2/public/static/js/reddit.js
+++ b/r2/r2/public/static/js/reddit.js
@@ -215,7 +215,7 @@ function click_thing(elem) {
 }
 
 function hide_thing(elem) {
-    $(elem).thing().fadeOut(function(elem) { 
+    $(elem).thing().fadeOut(function() { 
             $(this).toggleClass("hidden");
             unexpando_child(elem);
     });


### PR DESCRIPTION
When a video preview is played, and then the post is hidden, the video continues to play because the `div.expando` contents are not emptied. See [issue #233](https://github.com/reddit/reddit/issues/233) for discussion.

This patch fixes the this issue by calling the pre-existing logic that is called when a post is collapsed. 
