### PR TITLE
Remove two extra quotes from the reddit HTML.

### DIFF
--- a/r2/r2/templates/reddit.html
+++ b/r2/r2/templates/reddit.html
@@ -102,12 +102,12 @@
   %endif
 
   <!--[if lt IE 7]>
-    <link rel="stylesheet" href="${static('reddit-ie6-hax.css')}"" 
+    <link rel="stylesheet" href="${static('reddit-ie6-hax.css')}"
           type="text/css" />
   <![endif]-->
 
   <!--[if lt IE 8]>
-    <link rel="stylesheet" href="${static('reddit-ie7-hax.css')}"" 
+    <link rel="stylesheet" href="${static('reddit-ie7-hax.css')}"
           type="text/css" />
   <![endif]-->
 </%def>


### PR DESCRIPTION
See attached commit.

I got tired of seeing this in the reddit source:

```
<!--[if lt IE 7]><link rel="stylesheet" href="http://www.redditstatic.com/reddit-ie6-hax.jbdCLG3Tiv8.css"" type="text/css" /><![endif]--><!--[if lt IE 8]><link rel="stylesheet" href="http://www.redditstatic.com/reddit-ie7-hax.OpXf7sDBy28.css"" type="text/css" /><![endif]-->
```

Note the double-double-quotes in the tags.

And heck, I'm not even an IE user. Don't know if this actually makes a difference in IE's parsing, but it helps restore my sanity. :)
