### PR TITLE
Add margin-left to link flairs in click-gadget

### DIFF
--- a/r2/r2/public/static/css/reddit.css
+++ b/r2/r2/public/static/css/reddit.css
@@ -1219,6 +1219,7 @@ a.star { text-decoration: none; color: #ff8b60 }
 .gadget .reddit-entry {margin-left: 20px;}
 .gadget .right {text-align: right;}
 
+.click-gadget .linkflair {margin-left: 5px;}
 
 /* comments */
 


### PR DESCRIPTION
They look like this right now:
![](http://gm4.in/i/Z3.png)
There is no space between link and flair. Adding 5px margin-left fixes this problem.
