### PR TITLE
Mobile CSS rule addition for post submitter

### DIFF
--- a/r2/r2/public/static/css/mobile.css
+++ b/r2/r2/public/static/css/mobile.css
@@ -150,4 +150,4 @@ ul {
 .flair, .linkflair { color: #545454; background-color: #F5F5F5; border: 1px solid #DEDEDE; }
 .linkflair { display: inline-block; font-size: small; max-width: 10em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 a.author, .flair, .linkflair { margin-right: 0.5em }
-.author.submitter { color: white; background-color: #5F99CF padding: 0 2px 0 2px; }
+.author.submitter { color: white; background-color: #5F99CF; padding: 0 4px; }


### PR DESCRIPTION
Hi there, I found a very minor but useful addition that could be made to the mobile CSS to highlight the original poster in a similar fashion to the non-mobile version, minus the jazzing up with border radius. I'm unsure if there's any rules around what should go inside the mobile css, but I think this is something that would improve readability when browsing through long comment threads, IAMA's etc.
