### PR TITLE
Change midcol width so that 4-number votes aren't clipped

### DIFF
--- a/r2/r2/lib/template_helpers.py
+++ b/r2/r2/lib/template_helpers.py
@@ -235,7 +235,7 @@ def replace_render(listing, item, render_func):
                 elif mid_margin == 1:
                     mid_margin = "15px"
                 else:
-                    mid_margin = "%dex" % (mid_margin+1)
+                    mid_margin = "%.1fex" % (mid_margin+1.1)
 
                 replacements["midcolmargin"] = mid_margin
 


### PR DESCRIPTION
http://i.imgur.com/IO0Ap.png

Once you reach a thousand likes, the number is ever so slightly clipped. Changing 5ex to 5.1ex fixes the issue.
The image shows the clipping happening on the first number, after the fix it looks like the second one.
