### PR TITLE
Correctly escape special characters in RSS feed URLs

### DIFF
--- a/r2/r2/templates/link.xml
+++ b/r2/r2/templates/link.xml
@@ -25,6 +25,7 @@
    from r2.lib.template_helpers import add_sr, get_domain
    from r2.models import FakeSubreddit
    from r2.lib.filters import unsafe, safemarkdown
+   from urllib import quote_plus
 %>
 <%
    permalink = add_sr(thing.permalink, force_hostname = True)
@@ -32,6 +33,7 @@
       url = thing.mousedown_url
    else:
       url = permalink
+   url = quote_plus(url.encode('utf8'), '/:')
    use_thumbs = thing.has_thumbnail and thing.thumbnail and not request.GET.has_key("nothumbs")
  %>
 <item>


### PR DESCRIPTION
As discussed on IRC. Some RSS clients (e.g. NetNewsWire) choke on special characters in URLs.

The problem I'm fixing can be demonstrated by running ` curl http://www.reddit.com/r/stereotest/.rss | grep -o -E http://.+?müllers '. The <link> URLs should contain m%C3%BCllers instead of müllers.

This patch tells quote_plus to urlencode the url strings' special characters to their UTF8 code, unless they are the safe characters ':' or '/'. 
