### PR TITLE
Install script uses outdated bash redirect technique

### DIFF
--- a/install-reddit.sh
+++ b/install-reddit.sh
@@ -81,7 +81,7 @@ fi
 set -x
 
 # create the user if non-existent
-if ! id $REDDIT_USER > /dev/null 2>&1; then
+if ! id $REDDIT_USER &> /dev/null; then
     adduser --system $REDDIT_USER
 fi
 


### PR DESCRIPTION
Back in the day, when you wanted to redirect both stdout and stderr, you did it like so:

./script > /dev/null 2>&1

The current installation script uses this technique. However, Bash has for some time allowed the code above to be written more elegantly like so:

./script &> /dev/null

I have changed the installation script to utilize this feature.
