### PR TITLE
minor bug fix and update for install-reddit.sh

### DIFF
--- a/install-reddit.sh
+++ b/install-reddit.sh
@@ -171,8 +171,9 @@ done
 ###############################################################################
 if [ ! -d $REDDIT_HOME ]; then
     mkdir -p $REDDIT_HOME
-    chown $REDDIT_OWNER $REDDIT_HOME
 fi
+
+chown $REDDIT_OWNER $REDDIT_HOME
 
 cd $REDDIT_HOME
 
@@ -187,7 +188,7 @@ fi
 ###############################################################################
 # Configure Cassandra
 ###############################################################################
-if ! echo | cassandra-cli -h localhost -k reddit > /dev/null 2>&1; then
+if ! echo | cassandra-cli -h localhost -k reddit &> /dev/null; then
     echo "create keyspace reddit;" | cassandra-cli -h localhost -B
 fi
 


### PR DESCRIPTION
In the 'if' clause at line 172, I remove the chown and place it after the if clause.  This is done because in the current system, if $REDDIT_HOME already exists, we go ahead and skip mkdir'ing it, but also skip chowning it do $REDDIT_OWNER. This is a bug. What is the point of using mkdir -p (which only creates the dir if it does not exist) if we are not going to bother chowning a pre-existing directory with the same name as $REDDIT_HOME to $REDDIT_OWNER?

Putting chown after the if clause, as I do in my new code, solves this problem. In the new code, if there is already a directory that has the same name as $REDDIT_HOME, we still chown it to $REDDIT_OWNER (not doing so could cause some subtle problems for sysadmins trying to install Reddit!). 

In addition to that, I found another instance of the outdated bash redirect technique at line 191. Not sure how I missed this in my last push, but it has been updated. 
