### PR TITLE
Another instance of outdated Bash redirect technique in install-reddit.sh

### DIFF
--- a/install-reddit.sh
+++ b/install-reddit.sh
@@ -187,7 +187,7 @@ fi
 ###############################################################################
 # Configure Cassandra
 ###############################################################################
-if ! echo | cassandra-cli -h localhost -k reddit > /dev/null 2>&1; then
+if ! echo | cassandra-cli -h localhost -k reddit &> /dev/null; then
     echo "create keyspace reddit;" | cassandra-cli -h localhost -B
 fi
 


### PR DESCRIPTION
Uses 2>&1 instead of &>, went ahead and corrected.
