### PR TITLE
Removed unnecessary import

### DIFF
--- a/r2/r2/lib/translation.py
+++ b/r2/r2/lib/translation.py
@@ -23,7 +23,6 @@
 import json
 import os
 import pylons
-import pylons.config
 from pylons.i18n.translation import translation, LanguageError, NullTranslations
 
 try:


### PR DESCRIPTION
Calling 'import pylon.config' (which is not an actual module) was breaking the build process...
