### PR TITLE
Include user flair class in body tag

### DIFF
--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -436,7 +436,7 @@ class Reddit(Templated):
                 if c.cname:
                     classes.add('cname')
                 flair = wrapped_flair(c.user, c.site, False)
-                flair_enabled, _, _, flair_css_class = flair
+                flair_enabled, _pos, _text, flair_css_class = flair
                 if flair_enabled and flair_css_class:
                     for flair_css_class in flair_css_class.split():
                         classes.add('userflair-%s' % flair_css_class)


### PR DESCRIPTION
Would open some interesting customizing possibilities if the body tag included the user's flair classes, just like it includes the "loggedin" etc. classes.

This might cause surprises with some stylesheets (if they've been using the flair classes without being more specific about it), so maybe the class should be named differently (user-flair-xxx maybe).
