### PR TITLE
Added Error value for Bad CSS on API

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -1217,6 +1217,8 @@ class ApiController(RedditController, OAuth2ResourceController):
             form.set_html(".status", _('validation errors'))
             form.set_html(".errors ul", ''.join(error_items))
             form.find('.errors').show()
+            c.errors.add(errors.BAD_CSS, field = "stylesheet_contents")
+            form.has_errors("stylesheet_contents", errors.BAD_CSS)
             return
         else:
             form.find('.errors').hide()
@@ -1239,6 +1241,8 @@ class ApiController(RedditController, OAuth2ResourceController):
             except ConflictException as e:
                 form.set_html(".status", _('conflict error'))
                 form.set_html(".errors ul", _('There was a conflict while editing the stylesheet'))
+                c.errors.add(errors.CSS_CONFLICT, field = "stylesheet_contents")
+                form.has_errors("stylesheet_contents", errors.CSS_CONFLICT)
                 form.find('#conflict_box').show()
                 form.set_inputs(conflict_old=e.your,
                                 prevstyle=e.new_id, stylesheet_contents=e.new)

--- a/r2/r2/controllers/errors.py
+++ b/r2/r2/controllers/errors.py
@@ -92,6 +92,8 @@ error_list = dict((
         ('NO_LINKS', _("that reddit only allows text posts")),
         ('TOO_OLD', _("that's a piece of history now; it's too late to reply to it")),
         ('BAD_CSS_NAME', _('invalid css name')),
+        ('BAD_CSS',_('invalid css')),
+        ('CSS_CONFLICT',_('css been edited since pageload')),
         ('TOO_MUCH_FLAIR_CSS', _('too many flair css classes')),
         ('BAD_FLAIR_TARGET', _('not a valid flair target')),
         ('OAUTH2_INVALID_CLIENT', _('invalid client id')),


### PR DESCRIPTION
Altered the API to return an error upon invalid CSS rather then silently failing.
Instead of a silent fail, this pull request alters it to return the newly added error BAD_CSS
If there is a conflict, it will return the error CSS_CONFLICT
