### PR TITLE
The submit button has a style that only targets Firefox. 

### DIFF
--- a/r2/r2/public/static/css/reddit.css
+++ b/r2/r2/public/static/css/reddit.css
@@ -992,7 +992,10 @@ a.author { margin-right: 0.5em; }
 }
 
 .wiki-page-content {
-    margin-right: 315px;
+    overflow: hidden;
+}
+#editform {
+    margin-right: 10px;
 }
 .discussionlink {
     display: inline-block;


### PR DESCRIPTION
Border radius was only being applied to left corners in Firefox, since that was the only vendor prefix used.

This makes the left broder-radius available in all browsers that support it.
