### PR TITLE
subreddit: UploadedImage error call should have form_id specified.

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -1393,7 +1393,7 @@ class ApiController(RedditController, OAuth2ResourceController):
                 errors['IMAGE_ERROR'] = _("too many images (you only get %d)") % g.max_sr_images
 
         if any(errors.values()):
-            return UploadedImage("", "", "", errors=errors).render()
+            return UploadedImage("", "", "", errors=errors, form_id=form_id).render()
         else:
             try:
                 new_url = cssfilter.save_sr_image(c.site, file, suffix ='.' + img_type)


### PR DESCRIPTION
Fixes the "bad image name" and "too many images" errors not dislaying.
