### PR TITLE
validator: Reset has_errors every call.

### DIFF
--- a/r2/r2/controllers/validator/validator.py
+++ b/r2/r2/controllers/validator/validator.py
@@ -105,6 +105,7 @@ class Validator(object):
         return param_info
 
     def __call__(self, url):
+        self.has_errors = False
         a = []
         if self.param:
             for p in utils.tup(self.param):


### PR DESCRIPTION
Currently an invalid address will cause the validator to never return an address again in the same app.  Was also causing bugs in wiki.
