### PR TITLE
add parent_id to "more" things returned from morecomments.json

### DIFF
--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -403,7 +403,8 @@ class MoreCommentJsonTemplate(CommentJsonTemplate):
     _data_attrs_ = dict(id           = "_id36",
                         name         = "_fullname",
                         children     = "children",
-                        count        = "count")
+                        count        = "count",
+                        parent_id    = "parent_id")
 
     def kind(self, wrapped):
         return "more"


### PR DESCRIPTION
This fixes issue #423. morecomments already returns parent_ids, but the
.json version does not. Without parent_id, you cannot know at what
depth the "load more comments…" links should go
