### PR TITLE
Fix "hot" algorithm to treat negative score sanely

### DIFF
--- a/r2/r2/lib/db/_sorts.pyx
+++ b/r2/r2/lib/db/_sorts.pyx
@@ -53,7 +53,7 @@ cpdef double _hot(long ups, long downs, double date):
     else:
         sign = 0
     seconds = date - 1134028003
-    return round(order + sign * seconds / 45000, 7)
+    return round(order * sign + seconds / 45000, 7)
 
 cpdef double controversy(long ups, long downs):
     """The controversy sort."""

--- a/sql/functions.sql
+++ b/sql/functions.sql
@@ -21,7 +21,7 @@
 -------------------------------------------------------------------------------
 
 create or replace function hot(ups integer, downs integer, date timestamp with time zone) returns numeric as $$
-    select round(cast(log(greatest(abs($1 - $2), 1)) + sign($1 - $2) * (date_part('epoch', $3) - 1134028003) / 45000.0 as numeric), 7)
+    select round(cast(log(greatest(abs($1 - $2), 1)) * sign($1 - $2) + (date_part('epoch', $3) - 1134028003) / 45000.0 as numeric), 7)
 $$ language sql immutable;
 
 create or replace function score(ups integer, downs integer) returns integer as $$


### PR DESCRIPTION
The hot algorithm applies the "sign" of a post's score weirdly. This [has been noticed before](http://bibwild.wordpress.com/2012/05/08/reddit-story-ranking-algorithm/).

The time-based value is a large value that grows over time, so applying the sign to that yields weird results for posts with negative score. Not only do posts with a negative score rank lower than all positive posts, but _older_ negative posts actually rank higher than _newer_ negative posts, all else being equal.

Here's what I mean:

``` python
_hot(1, 0, 1262304000) #=> 2850.0
_hot(0, 1, 1262304000) #=> -2851.0
_hot(0, 1, 1353107345) #=> -4869.0
```

With this patch, it returns much more expected values:

``` python
_hot(1, 0, 1262304000) #=> 2850.0
_hot(0, 1, 1262304000) #=> 2850.0
_hot(0, 1, 1353107345) #=> 4868.0
```
