### PR TITLE
Add "outline: none" to .arrow

### DIFF
--- a/r2/r2/public/static/css/reddit.css
+++ b/r2/r2/public/static/css/reddit.css
@@ -605,10 +605,11 @@ ul.flat-vert {text-align: left;}
     display: block;
     cursor: pointer;
     background-position: center center;
-    background-repeat: no-repeat; 
+    background-repeat: no-repeat;
     width: 15px;
     margin-left: auto;
-    margin-right: auto; 
+    margin-right: auto;
+    outline: none;
 }
 
 .arrow.upmod { 


### PR DESCRIPTION
With 2ddfab7e6977c5acbb9c58f716c34aeb5e757a0c, when clicking buttons, buttons appear to have outlines (atleast in Chrome), this commit removes the outline.

![2012 12 17_22h42m22s_003_](https://f.cloud.github.com/assets/613331/17842/7bd0c2a8-488a-11e2-93a6-9a6c3ce6ddfe.png)
