### PR TITLE
Show hidden submissions in moderator listings.

### DIFF
--- a/r2/r2/controllers/front.py
+++ b/r2/r2/controllers/front.py
@@ -514,7 +514,7 @@ class FrontController(RedditController, OAuth2ResourceController):
 
         def keep_fn(x):
             # no need to bother mods with banned users, or deleted content
-            if getattr(x,'hidden',False) or x._deleted:
+            if x._deleted:
                 return False
             if getattr(x,'author',None) == c.user and c.user._spam:
                 return False


### PR DESCRIPTION
As per a discussion on #reddit-dev with rram and kemitche it was semi-agreed upon that using the "hide" feature to hide submissions from moderator listings was not the appropriate way users should be doing things as "hide" should be used to prevent the submission from appearing in "normal" listings.
