### PR TITLE
Provide developer-friendly attributes in the modaction json.

### DIFF
--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -717,10 +717,20 @@ class SubredditSettingsTemplate(ThingJsonTemplate):
 class ModActionTemplate(ThingJsonTemplate):
     _data_attrs_ = dict(sr_id36='sr_id36',
                         mod_id36='mod_id36',
+                        id='_fullname',
+                        subreddit='sr_name',
+                        mod='author',
+                        created_utc='date',
                         action='action',
                         details='details',
                         description='description',
                         target_fullname='target_fullname')
+
+    def thing_attr(self, thing, attr):
+        if attr == 'date':
+            return (time.mktime(thing.date.astimezone(pytz.UTC).timetuple())
+                    - time.timezone)
+        return ThingJsonTemplate.thing_attr(self, thing, attr)
 
     def kind(self, wrapped):
         return 'modaction'


### PR DESCRIPTION
I removed the base36 ids because frankly they're useless to a client-side developer. I realize this has the potential to break _some_ API clients, but I'm going to start with this change.
