### PR TITLE
Allow editing from self userpages.

### DIFF
--- a/r2/r2/templates/printablebuttons.html
+++ b/r2/r2/templates/printablebuttons.html
@@ -287,11 +287,11 @@
           ${self.bylink_button(_("parent"), thing.parent_permalink)}
         </li>
       %endif
-      %if thing.is_author:
-        <li>
-          ${self.simple_button(_("edit"), "edit_usertext", css_class="edit-usertext")}
-        </li>
-      %endif
+    %endif
+    %if thing.is_author:
+      <li>
+        ${self.simple_button(_("edit"), "edit_usertext", css_class="edit-usertext")}
+      </li>
     %endif
     ${self.banbuttons()}
     ${self.distinguish()}


### PR DESCRIPTION
Aside from being generally useful, this will be the only way people can edit their own comments when the comments tree queue is backed up.
