### PR TITLE
Use an absolute URL for self-posts for the embeddable widget

### DIFF
--- a/r2/r2/templates/link.htmllite
+++ b/r2/r2/templates/link.htmllite
@@ -56,8 +56,13 @@
     %if c.site.link_flair_position == 'left' and thing.flair_text:
       ${flair()}
     %endif
-    <a href="${thing.href_url}" class="reddit-link-title"
+    <a class="reddit-link-title"
       ${optionalstyle("text-decoration:none;color:#336699;font-size:small;")}
+       %if thing.is_self:
+         href="${permalink}"
+       %else:
+         href="${thing.href_url}"
+       %endif
        %if thing.nofollow:
          rel="nofollow"
        %endif


### PR DESCRIPTION
This should fix issues #115 and #312
