### PR TITLE
wikitoc: Fix some headers ending up at the wrong level.

### DIFF
--- a/r2/r2/lib/filters.py
+++ b/r2/r2/lib/filters.py
@@ -279,6 +279,7 @@ def inject_table_of_contents(soup, prefix):
         return
     tocdiv = Tag(soup, "div", [("class", "toc")])
     parent = Tag(soup, "ul")
+    parent.level = 0
     tocdiv.append(parent)
     level = 0
     previous = 0
@@ -314,12 +315,14 @@ def inject_table_of_contents(soup, prefix):
         
         if previous and thislevel > previous:
             newul = Tag(soup, "ul")
+            newul.level = thislevel
             parent.append(newul)
             parent = newul
             level += 1
         elif level and thislevel < previous:
-            parent = parent.findParent("ul")
-            level -= 1
+            while level and parent.level > thislevel:
+                parent = parent.findParent("ul")
+                level -= 1
         
         previous = thislevel
         parent.append(li)


### PR DESCRIPTION
The assumption was made that when a header ended it would go down one level, this code corrects that and goes down as many levels as it needs to in order to match the header tag level of the parent.

Example input:

```
   # Level 1

   ## Level 2

   ### Level 3

   # Level 1
```

The last Level 1 would end up being a level 2 in the table of contents
