### PR TITLE
Prevent three scores being shown in the widget at the same time

### DIFF
--- a/r2/r2/templates/link.htmllite
+++ b/r2/r2/templates/link.htmllite
@@ -37,6 +37,12 @@
   %endif
 </%def>
 
+<%def name="hide_if_appropriate(state)">
+  %if thing.like_cls != state:
+   ${optionalstyle("display: none;")}
+  %endif
+</%def>
+
 <%def name="entry()">
 <% 
    from r2.lib.strings import Score
@@ -96,13 +102,13 @@
       <%
        score_dislikes, score_unvoted, score_likes = thing.display_score
        %>
-      <span class="score dislikes">
+      <span class="score dislikes" ${hide_if_appropriate('dislikes')}>
          ${score_dislikes}
       </span>
-      <span class="score unvoted">
+      <span class="score unvoted" ${hide_if_appropriate('unvoted')}>
          ${score_unvoted}
       </span>
-      <span class="score likes">
+      <span class="score likes" ${hide_if_appropriate('likes')}>
          ${score_likes}
       </span>
       &#32;|&#32;


### PR DESCRIPTION
![Screenshot from 2013-02-04 22:21:12](https://f.cloud.github.com/assets/1097349/125660/27add248-6f1c-11e2-848e-023bd18910a3.png)

This should fix #391

On [the widget page](http://www.reddit.com/widget) the additional scores are hidden using an external stylesheet, this patch hides them using inline styles if it's appropriate to do so and will work on non reddit.com websites.

I didn't test with buttons that allow voting as it's hassle to set up, but as far as I can tell they use iframes and separate templates in `r2/public/static/buttons` and shouldn't be broken.
