### PR TITLE
Add width and height attributes to static image in HTML template

### DIFF
--- a/r2/r2/templates/over18.html
+++ b/r2/r2/templates/over18.html
@@ -26,7 +26,7 @@
   <p class="error">
     ${_("you must be at least eighteen to view this reddit")}
   </p>
-  <img src="${static('over18.png')}" alt="" height="254px" width="180px" />
+  <img src="${static('over18.png')}" alt="" height="254" width="180" />
   
   <form method="post" action="" class="pretty-form"
       ${"target='_top'" if c.cname else ""}>

--- a/r2/r2/templates/passwordverificationform.html
+++ b/r2/r2/templates/passwordverificationform.html
@@ -28,7 +28,7 @@
 <%namespace file="utils.html" import="error_field"/>
 
 <div class="content over18" style="text-align: center">
-  <img src="${static('over18.png')}" alt="" height="254px" width="180px" />
+  <img src="${static('over18.png')}" alt="" height="254" width="180" />
 
   <h1>let me see your papers</h1>
 


### PR DESCRIPTION
Hey there!

I've added `width` and `height` attributes to the `over18.png` image. I've done this to stop the annoying content reflow (therefore moving the yes/no buttons) after the page has loaded.

I don't know if there's a reason this hasn't been done before? Maybe because you'd have to maintain it if the image changed?

Anywho, :heart: reddit!
