### PR TITLE
Set .toc to have a max-width of 300px;

### DIFF
--- a/r2/r2/public/static/css/wiki.less
+++ b/r2/r2/public/static/css/wiki.less
@@ -120,6 +120,9 @@
         }
 
         // Wiki table of contents 
+        .md.wiki > .toc {
+            max-width: 300px;
+        }
         .md.wiki > .toc > ul {
             float: right;
             padding: 10px 25px;


### PR DESCRIPTION
Currently the default .toc can get annoyingly wide.  Here I've set it to 300px which is as wide as the subreddit sidebar.
