### PR TITLE
Set a max-width of 300px on wiki's toc

### DIFF
--- a/r2/r2/public/static/css/wiki.less
+++ b/r2/r2/public/static/css/wiki.less
@@ -120,16 +120,14 @@
         }
 
         // Wiki table of contents 
-        .md.wiki > .toc {
-            max-width: 300px;
-            float: right;
-        }
         .md.wiki > .toc > ul {
             float: right;
             padding: 10px 25px;
             margin-right: 0;
             border: 1px solid #8D9CAA;
             list-style: none;
+            max-width: 300px;
+            float: right;
         }
         .md.wiki > .toc > ul ul {
             margin: 4px 0;


### PR DESCRIPTION
The default allows the toc to get rather wide.  Here I've set it to be as wide as the default subreddit sidebar.
