### PR TITLE
Fix duplicate url submission workflow

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -321,7 +321,9 @@ class ApiController(RedditController, OAuth2ResourceController):
                 g.stats.simple_event('spam.shame.link')
             elif form.has_errors("url", errors.ALREADY_SUB):
                 check_domain = False
-                u = url[0].already_submitted_link
+                u = utils.tup(Link._by_url(url, sr))[0]
+                u = u.already_submitted_link(url=url, title=title)
+
                 if extension:
                     u = UrlParser(u)
                     u.set_extension(extension)

--- a/r2/r2/controllers/front.py
+++ b/r2/r2/controllers/front.py
@@ -252,7 +252,10 @@ class FrontController(RedditController, OAuth2ResourceController):
         # check if we just came from the submit page
         infotext = None
         if request.get.get('already_submitted'):
-            infotext = strings.already_submitted % article.resubmit_link()
+            infotext = strings.already_submitted % article.resubmit_link(
+                sr_url=True,
+                url=request.get.get('already_submitted'),
+                title=request.get.get('title'))
 
         check_cheating('comments')
 
@@ -920,11 +923,16 @@ class FrontController(RedditController, OAuth2ResourceController):
         if url and not resubmit:
             # check to see if the url has already been submitted
             links = link_from_url(url)
+
             if links and len(links) == 1:
-                return self.redirect(links[0].already_submitted_link)
+                u = links[0].already_submitted_link(url=url, title=title)
+                return self.redirect(u)
             elif links:
                 infotext = (strings.multiple_submitted
-                            % links[0].resubmit_link())
+                            % links[0].resubmit_link(
+                                sr_url=True,
+                                url=request.get.get('already_submitted'),
+                                title=request.get.get('title')))
                 res = BoringPage(_("seen it"),
                                  content=wrap_links(links),
                                  infotext=infotext).render()

--- a/r2/r2/lib/validator/validator.py
+++ b/r2/r2/lib/validator/validator.py
@@ -1182,7 +1182,7 @@ class VUrl(VRequired):
             try:
                 l = Link._by_url(url, sr)
                 self.error(errors.ALREADY_SUB)
-                return utils.tup(l)
+                return url
             except NotFound:
                 return url
         return self.error(errors.BAD_URL)

--- a/r2/r2/models/link.py
+++ b/r2/r2/models/link.py
@@ -120,13 +120,15 @@ class Link(Thing, Printable):
             LinksByUrl._set_values(LinksByUrl._key_from_url(self.url),
                                    {self._id36: ''})
 
-    @property
-    def already_submitted_link(self):
-        return self.make_permalink_slow() + '?already_submitted=true'
+    def already_submitted_link(self, url=None, title=None):
+        return self.make_permalink_slow() + \
+            '?already_submitted=' + url_escape(url or self.url) + \
+            '&title=' + url_escape(title or self.title)
 
-    def resubmit_link(self, sr_url=False):
+    def resubmit_link(self, sr_url=False, url=False, title=False):
         submit_url = self.subreddit_slow.path if sr_url else '/'
-        submit_url += 'submit?resubmit=true&url=' + url_escape(self.url)
+        submit_url += 'submit?resubmit=true&url=' + url_escape(url or self.url)
+        submit_url += '&title=' + url_escape(title or self.title)
         return submit_url
 
     @classmethod


### PR DESCRIPTION
Previously when a duplicate url fragment was submitted, the user was
redirected to the comments page where they were provided a link to
resubmit the link. This resulting link did not include the original
url. This patch adds changes that preserve the url and title
throughout the submission workflow.