### PR TITLE
Include "has_verified_email" flag in IdentityJsonTemplate.

### DIFF
--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -251,6 +251,7 @@ class IdentityJsonTemplate(ThingJsonTemplate):
                                                 is_gold = "gold",
                                                 is_mod = "is_mod",
                                                 over_18 = "pref_over_18",
+                                                has_verified_email = "email_verified",
                                                 )
 
     def thing_attr(self, thing, attr):


### PR DESCRIPTION
Include `has_verified_email` flag in `IdentityJsonTemplate` so that when you make a `GET` request to `/user/<username>/about.json`, the JSON response includes the flag that tells whether or not the user has successfully verified their email address.

```
{
    "kind": "t2",
    "data": {
        "has_mail": false,
        "name": "reddit",
        "is_friend": false,
        "created": 1364192756.0,
        "modhash": "reddit",
        "created_utc": 1364189156.0,
        "link_karma": 1,
        "comment_karma": 0,
        "over_18": false,
        "is_gold": false,
        "is_mod": true,
        "has_verified_email": true,     <------------ this
        "id": "1",
        "has_mod_mail": false
    }
}
```

The motivation for this change is to encourage users to provide and verify their email address in the event they get a `QUOTA_FILLED` error from a link submission. API clients may inspect a user's `has_verified_email` flag to determine whether or not to recommend the user to update their email address.
