### PR TITLE
Compress spaces in submission titles

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -378,7 +378,7 @@ class ApiController(RedditController, OAuth2ResourceController):
             sendreplies = kind == 'self'
 
         # well, nothing left to do but submit it
-        l = Link._submit(request.post.title, url if kind == 'link' else 'self',
+        l = Link._submit(spaceCompress(request.post.title), url if kind == 'link' else 'self',
                          c.user, sr, ip, spam=c.user._spam, sendreplies=sendreplies)
 
         if banmsg:


### PR DESCRIPTION
This patch simply runs `spaceCompress()` from `filters.py` on the submission title.

Helps with API clients to prevent crazy formatting like this:
![F6oqXSP](https://f.cloud.github.com/assets/87961/314224/88c6430e-97c5-11e2-8c04-c32afb1bc4a0.png)

Of course the alternative is to handle whitespace compression on the client side, but when 99% of posts have well-formatted titles, it's easy to get blindsided by the rare one that doesn't.
