### PR TITLE
Fixed missing whitespace in goldinfopage.html template

### DIFF
--- a/r2/r2/public/static/css/goldinfo.less
+++ b/r2/r2/public/static/css/goldinfo.less
@@ -129,7 +129,7 @@ section#about-gold {
 
         .or {
             font-size: 18px;
-            margin: 0 16px;
+            margin: 0 16px 0 10px;
         }
     }
 

--- a/r2/r2/templates/goldinfopage.html
+++ b/r2/r2/templates/goldinfopage.html
@@ -50,8 +50,8 @@
       <h1>${_('Make reddit better.')}</h1>
       <p>${_('reddit gold adds shiny extra features to your account that are made possible thanks to support from people like you.')}</p>
       <div class="actions">
-        <a class="buy-gold-button" href="/gold">${_('buy reddit gold')}</a>
-        <span class="or"> ${_('or')}</span>
+        <a class="buy-gold-button" href="/gold">${_('buy reddit gold')}</a>&#32;
+        <span class="or">${_('or')}</span>
         <a class="postcard-button" href="#postcard"><img src="${static('gold/stamp.png')}" alt=""> ${_('send us a postcard')}</a>
       </div>
     </header>


### PR DESCRIPTION
Looked shitty in the search engine: 

![Bildschirmfoto 2013-03-30 um 14 04 53](https://f.cloud.github.com/assets/944459/320388/713ac480-993c-11e2-8747-26eb3a57912c.png)
