### PR TITLE
Fixes bug that prevents generation of new captcha iden for failed calls to VCaptcha-decorated API methods

### DIFF
--- a/r2/r2/lib/validator/validator.py
+++ b/r2/r2/lib/validator/validator.py
@@ -277,7 +277,7 @@ def _validatedForm(self, self_method, responder, simple_vals, param_vals,
     # add data to the output on some errors
     for validator in simple_vals:
         if (isinstance(validator, VCaptcha) and
-            form.has_errors('captcha', errors.BAD_CAPTCHA)):
+            (form.has_errors('captcha', errors.BAD_CAPTCHA) or c.errors)):
             form.new_captcha()
         elif (isinstance(validator, VRatelimit) and
               form.has_errors('ratelimit', errors.RATELIMIT)):


### PR DESCRIPTION
**How to reproduce the issue (one of the many ways, see bottom for more):**
1. Create a new reddit account (or login to one that still see/needs CAPTCHA)
2. Click "Submit a new text post" (don't worry, we won't actually submit anything)
3. For title, enter "test"
4. For subreddit, enter a non-existent subreddit name (e.g. "asfasdfasdfasdfsadf")
5. Enter the correct solution for the CAPTCHA challenge
6. Click "submit"

**Expected result:** The submission fails with the subreddit field decorated with the "that subreddit doesn't exist" error message AND the CAPTCHA image refreshes.

**Actual result:** The submission fails with the subreddit field decorated with the "that subreddit doesn't exist" error message BUT the CAPTCHA image _doesn't_ refresh.

**Summary of this change:** Update `validator.py` to issue new CAPTCHA identifier any time when calls to a `VCaptcha`-decorated API method fail.

**Additional notes:** The following API methods (along with their corresponding web forms) are affected by this bug:
- `POST_feedback` (bug reproducible at http://www.reddit.com/feedback/)
- `POST_compose` (bug reproducible at http://www.reddit.com/message/compose/)
- `POST_submit` (bug reproducible at http://www.reddit.com/submit)
- `POST_register` (bug masked by custom JavaScript UI Form error handler)
- `POST_share` (bug reproducible by clicking the share action link beneath each link)
