### PR TITLE
Add "/api/needs_captcha" method to determine if CAPTCHAs are needed.

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -171,6 +171,15 @@ class ApiController(RedditController, OAuth2ResourceController):
         if not (responder.has_errors("user", errors.BAD_USERNAME)):
             return bool(user)
 
+    @validatedForm()
+    @api_doc(api_section.misc)
+    def POST_needs_captcha(self, form, jquery):
+        """
+        Check whether CAPTCHAs are needed for API methods that define the
+        "captcha" and "iden" parameters.
+        """
+        form._send_data(needs_captcha=c.user.needs_captcha())
+
     @validatedForm(VCaptcha(),
                    name=VRequired('name', errors.NO_NAME),
                    email=ValidEmails('email', num = 1),


### PR DESCRIPTION
This pull request proposes a new API method — `POST_needs_captcha` — that provides API clients a clean way to determine whether CAPTCHAs are needed when making certain API calls.

Right now, there two ways to determine whether CAPTCHAs are needed (list beneath each item describes their issues):
1. Make an API call without specifying `captcha` and `iden` and look at the response for `BAD_CAPTCHA` error.
   - Produces unnecessary error messages on the server side
   - Forces user interface to implement a two-page form or two-step process
2. Make a request for the HTML version of the corresponding web form (e.g. http://www.reddit.com/submit) and search the response text for the CAPTCHA iden token (e.g. regex: `"<input name=\"iden\" value=\"([^\"]+)\" type=\"hidden\"/>"`).
   - Error prone against HTML template changes
   - Require downloading unnecessary data (all the HTML surrounding the embedded iden)

The proposed API method resolves these issues.
