### PR TITLE
Don't show error when user click the verify email link twice.

### DIFF
--- a/r2/r2/controllers/front.py
+++ b/r2/r2/controllers/front.py
@@ -1176,9 +1176,11 @@ class FormsController(RedditController):
             # wrong user. log them out and try again.
             self.logout()
             return self.redirect(request.fullpath)
-        elif token and c.user.email_verified:
-            # they've already verified. consume and ignore this token.
-            token.consume()
+        elif c.user.email_verified:
+            # they've already verified.
+            if token:
+                # consume and ignore this token (if not already consumed).
+                token.consume()
             return self.redirect(dest)
         elif token and token.valid_for_user(c.user):
             # successful verification!


### PR DESCRIPTION
After a user verified their email address by clicking the verify email link, don't display error message when they re-click the email verify link the second time.

I think that is the original intent for the code that this commit replaces.
