### PR TITLE
Make submission page's subreddit auto-completion dropdown obey over18 state

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -3070,11 +3070,12 @@ class ApiController(RedditController, OAuth2ResourceController):
         c.user.pref_frame_commentspanel = False
         c.user._commit()
 
-    @json_validate(query = VPrintable('query', max_length = 50))
-    def POST_search_reddit_names(self, responder, query):
+    @json_validate(query=VPrintable('query', max_length=50),
+                   include_over_18=VBoolean('include_over_18', default=True))
+    def POST_search_reddit_names(self, responder, query, include_over_18):
         names = []
         if query:
-            names = search_reddits(query)
+            names = search_reddits(query, include_over_18)
 
         return {'names': names}
 

--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -2198,7 +2198,7 @@ class NewLink(Templated):
 
             self.formtabs_menu = JsNavMenu(buttons, type = 'formtab')
 
-        self.sr_searches = simplejson.dumps(popular_searches())
+        self.sr_searches = simplejson.dumps(popular_searches(include_over_18=c.over18))
 
         self.resubmit = resubmit
         if c.default_sr:

--- a/r2/r2/lib/template_helpers.py
+++ b/r2/r2/lib/template_helpers.py
@@ -150,6 +150,7 @@ def js_config(extra_config=None):
         "clicktracker_url": g.clicktracker_url,
         "uitracker_url": g.uitracker_url,
         "static_root": static(''),
+        "over_18": bool(c.over18),
     }
 
     if extra_config:

--- a/r2/r2/public/static/js/reddit.js
+++ b/r2/r2/public/static/js/reddit.js
@@ -638,7 +638,7 @@ function sr_search(query) {
     query = query.toLowerCase();
     var cache = sr_cache();
     if (!cache[query]) {
-        $.request('search_reddit_names.json', {query: query},
+        $.request('search_reddit_names.json', {query: query, include_over_18: r.config.over_18},
                   function (r) {
                       cache[query] = r['names'];
                       update_dropdown(r['names']);


### PR DESCRIPTION
This pull request updates submission page's subreddit auto-completion dropdown to not show over18 subreddits if user's over18 pref is false, which mirrors the behavior of subreddit topic recommender bar at http://www.reddit.com/subreddit (See: https://github.com/reddit/reddit/blob/master/r2/r2/controllers/api.py#L3179).

**Steps to reproduce:**
1. login to reddit
2. uncheck the over18 pref checkbox
3. go to the submission page and type "pics" into the subreddit input text field

**Expected result:**

The auto-completion dropdown box shows a list of _non-over18_ subreddits that have "pics" as their prefix.

**Actual result:**

The auto-completion dropdown shows the following subreddits:
- pics
- picsofmenwiththings
- picsofharlequincats
- PicsOfHorseDicks **[over18]**
- PicsOfCanineVaginas **[over18]**
- Picsofryanrunning
- picsofnathancowley
- picsofporn **[over18]**
- picsofdannyjsleeping
- PicsOfStonedMexicans

The proposed update makes it so that those subreddits only show up if they have set their account's over18 pref to true.

Lastly, it does so without breaking existing API clients by preserving the previous behavior as the default option for `POST_search_reddit_names`.
