### PR TITLE
fixed so Wikipedia links generate a thumbnail.

### DIFF
--- a/r2/r2/lib/scraper.py
+++ b/r2/r2/lib/scraper.py
@@ -1129,6 +1129,7 @@ class EmbedlyOEmbed(OEmbed):
         'https:\\/\\/crocodoc\\.com\\/.*|' +
         'https:\\/\\/.*\\.crocodoc\\.com\\/.*|' +
         'http:\\/\\/www\\.wikipedia\\.org\\/wiki\\/.*|' +
+        'http:\\/\\/.*\\.wikipedia\\.org\\.*\\/.*|' +
         'http:\\/\\/www\\.wikimedia\\.org\\/wiki\\/File.*|' +
         'https:\\/\\/urtak\\.com\\/u\\/.*|' +
         'https:\\/\\/urtak\\.com\\/clr\\/.*|' +


### PR DESCRIPTION
Urls like "http://en.wikipedia.org/wiki/Gropecunt_Lane" were returning no image originally. I added another wikipedia regex to handle this. I was using the test_url function to test.
