### PR TITLE
Fix unexpected captcha iden in response

### DIFF
--- a/r2/r2/lib/validator/validator.py
+++ b/r2/r2/lib/validator/validator.py
@@ -278,7 +278,7 @@ def _validatedForm(self, self_method, responder, simple_vals, param_vals,
     for validator in simple_vals:
         if (isinstance(validator, VCaptcha) and
             (form.has_errors('captcha', errors.BAD_CAPTCHA) or
-             form.has_error())):
+             (form.has_error() and c.user.needs_captcha()))):
             form.new_captcha()
         elif (isinstance(validator, VRatelimit) and
               form.has_errors('ratelimit', errors.RATELIMIT)):


### PR DESCRIPTION
This pull requests fixes two issues with regards to unexpected captcha identifier sent in API call responses. For clarity, I separated the fix for both issues into two commits.

---

**Issue 1: When a submission call succeeds, the server may attach an unexpected captcha identifier to the response.**

The reason why this happens is because `c.errors` contains all errors detected by `Validator`s (many of which are ignored by the controller methods). On the other hand, `form.has_error()` returns true if there exist errors that were explicitly set in controller methods with `has_errors(...)` and `set_error(...)`.

For example, when a link submission succeeds, `c.errors` contains the following values:
- `('NO_TEXT', 'extension')`
- `('NO_TEXT', 'text')`

while `form.has_error()` returns `False`.

---

**Issue 2: When a submission call fails for a user that doesn't need captcha, the server always attach an unexpected captcha identifier.**

The change avoids sending captcha iden for failed API calls by users that don't need it.
