### PR TITLE
OAuth2 spec compliance for token expires_in

### DIFF
--- a/r2/r2/controllers/oauth2.py
+++ b/r2/r2/controllers/oauth2.py
@@ -218,7 +218,7 @@ class OAuth2AccessController(MinimalController):
             if access_token:
                 resp["access_token"] = access_token._id
                 resp["token_type"] = access_token.token_type
-                resp["expires_in"] = access_token._ttl
+                resp["expires_in"] = int(access_token._ttl) if access_token._ttl else None
                 resp["scope"] = access_token.scope
                 if refresh_token:
                     resp["refresh_token"] = refresh_token._id


### PR DESCRIPTION
[OAuth2 spec](http://tools.ietf.org/html/rfc6749#appendix-A.14) calls for int type on expires_in.

Reddit is passing float:

{"access_token": "token", "token_type": "bearer", "expires_in": 3600.0, "scope": "identity"}
