### PR TITLE
Fix discussion page's "limit", "after", "before", "count" params.

### DIFF
--- a/r2/r2/controllers/front.py
+++ b/r2/r2/controllers/front.py
@@ -757,8 +757,9 @@ class FrontController(RedditController, OAuth2ResourceController):
 
         # only look up duplicates if it's not a self-post
         if not getattr(article, 'is_self', False):
-            builder = url_links_builder(article.url,
-                                        exclude=article._fullname)
+            builder = url_links_builder(article.url, exclude=article._fullname,
+                                        num=num, after=after, reverse=reverse,
+                                        count=count)
             num_duplicates = len(builder.get_items()[0])
             listing = LinkListing(builder).listing()
         else:

--- a/r2/r2/controllers/wiki.py
+++ b/r2/r2/controllers/wiki.py
@@ -207,7 +207,8 @@ class WikiController(RedditController):
     @validate(page=VWikiPage('page', restricted=True))
     def GET_wiki_discussions(self, page, num, after, reverse, count):
         page_url = add_sr("%s/%s" % (c.wiki_base_url, page.name))
-        builder = url_links_builder(page_url)
+        builder = url_links_builder(page_url, num=num, after=after,
+                                    reverse=reverse, count=count)
         listing = LinkListing(builder).listing()
         return WikiDiscussions(listing, page=page.name,
                                may_revise=this_may_revise(page)).render()

--- a/r2/r2/lib/utils/utils.py
+++ b/r2/r2/lib/utils/utils.py
@@ -1028,7 +1028,8 @@ def filter_links(links, filter_spam = False, multiple = True):
     # among those, show them the hottest one
     return links if multiple else links[0]
 
-def url_links_builder(url, exclude=None):
+def url_links_builder(url, exclude=None, num=None, after=None, reverse=None,
+                      count=None):
     from r2.models import IDBuilder, Link, NotFound
     from operator import attrgetter
 
@@ -1050,8 +1051,9 @@ def url_links_builder(url, exclude=None):
                         c.user_is_admin or
                         link.subreddit.is_moderator(c.user))))
 
-    builder = IDBuilder([link._fullname for link in links],
-                        skip=True, keep_fn=include_link)
+    builder = IDBuilder([link._fullname for link in links], skip=True,
+                        keep_fn=include_link, num=num, after=after,
+                        reverse=reverse, count=count)
 
     return builder
 


### PR DESCRIPTION
This pull request fixes the bug that causes discussion (for links and wikis) pages's `limit`, `after`, `before`, `count` parameter to not work at all.

**Examples**

For a link, the following URLs all show the same results:
- http://www.reddit.com/r/funny/duplicates/1aw7s5/
- http://www.reddit.com/r/funny/duplicates/1aw7s5/?limit=1
- http://www.reddit.com/r/funny/duplicates/1aw7s5/?after=t3_162prl

For a wiki, the following URLs all show the same results:
- http://www.reddit.com/wiki/discussions/reddiquette
- http://www.reddit.com/wiki/discussions/reddiquette?limit=1
- http://www.reddit.com/wiki/discussions/reddiquette?after=t3_1csk1m

Also, normally, the `limit` param is capped by `VLimit` at 100. This bug causes pages like http://www.reddit.com/r/funny/duplicates/1aw7s5/ to list more than 100 results per request.
