### PR TITLE
Fix bug that causes listing page to show "next" link when not expected.

### DIFF
--- a/r2/r2/models/builder.py
+++ b/r2/r2/models/builder.py
@@ -382,7 +382,7 @@ class QueryBuilder(Builder):
                 break;
 
             #if fewer results than we wanted, we're done
-            elif self.num and len(new_items) < self.num - num_have:
+            elif self.num and len(new_items) <= self.num - num_have:
                 done = True
                 have_next = False
 


### PR DESCRIPTION
This pull request fixes the listing page from showing unnecessary "next" link.

For example, if a listing page only have 2 results to show, appending `limit=2` query param to the URL causes the server to render a `next` link at the bottom of that page. This is not expected, because there are no additional results and clicking "next" link shows an empty page.
- http://www.reddit.com/user/PresidentObama/submitted/ (no "next" link)
- http://www.reddit.com/user/PresidentObama/submitted/?limit=2 (has "next" link)

This bug pretty much shows up every time when you visit the last page of a listing page and the number of results for that page equals the `limit` value.
