### PR TITLE
wiki: unsafe() diff html on conflict.

### DIFF
--- a/r2/r2/public/static/js/wiki.js
+++ b/r2/r2/public/static/js/wiki.js
@@ -107,7 +107,7 @@ r.wiki = {
                         ,specials = special.children('#specials')
                     specials.empty()
                     for(i in errors) {
-                        specials.append(errors[i]+'<br/>')
+                        specials.append($('<p>').text(errors[i]))
                     }
                     special.fadeIn('slow')
                 },


### PR DESCRIPTION
Fixes #755, was caused by a safety net put in place with 102ef36
