### PR TITLE
Add wiki page name to title and add wiki page class

### DIFF
--- a/r2/r2/lib/pages/wiki.py
+++ b/r2/r2/lib/pages/wiki.py
@@ -119,13 +119,17 @@ class WikiBasePage(Reddit):
         
         self.inner_content = inner_content
 
+        page_classes = None
+
         if page and "title" not in context:
             context["title"] = _("%(page)s - %(site)s") % {
                 "site": c.site.name,
                 "page": page}
+            page_classes = ['wiki-page-%s' % page]
 
         Reddit.__init__(self, extra_js_config={'wiki_page': page}, 
-                        show_wiki_actions=True, **context)
+                        show_wiki_actions=True, page_classes=page_classes,
+                        **context)
 
 class WikiPageView(WikiBasePage):
     def __init__(self, content, page, diff=None, **context):


### PR DESCRIPTION
Fixes #638 and adds a page name specific class to the body to allow wiki page specific themes.
