### PR TITLE
Remove space from words "up vote" and "down vote"

### DIFF
--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -193,7 +193,7 @@ class Reddit(Templated):
                     c.site.domain.endswith("imgur.com")):
                 self.infobar = InfoBar(message=
                     _("imgur.com domain listings (including this one) are "
-                      "currently disabled to speed upvote processing.")
+                      "currently disabled to speed up vote processing.")
                 )
             elif isinstance(c.site, AllMinus) and not c.user.gold:
                 self.infobar = InfoBar(message=strings.all_minus_gold_only,


### PR DESCRIPTION
Upvote and downvote are used globally across the site, so the sidebar should use it as well.
