### PR TITLE
submit.compact: Compact submit should use .name of the subreddit.

### DIFF
--- a/r2/r2/templates/newlink.compact
+++ b/r2/r2/templates/newlink.compact
@@ -98,7 +98,8 @@ ${thing.formtabs_menu}
 
 <div class="spacer">
   <%utils:round_field title="${_('subreddit')}" id="reddit-field">
-    ${reddit_selector(thing.default_sr.name, thing.sr_searches, thing.subreddits)}
+    <% sr_name = thing.default_sr.name if thing.default_sr else None %>
+    ${reddit_selector(sr_name, thing.sr_searches, thing.subreddits)}
   </%utils:round_field>
 </div>
 


### PR DESCRIPTION
The compact submit subreddit box was getting populated with the string of the subreddit Eg. '<code><Subreddit 12></code>' instead of the name of the subreddit.
