### PR TITLE
wiki: Add a create page.

### DIFF
--- a/r2/r2/config/routing.py
+++ b/r2/r2/config/routing.py
@@ -260,6 +260,7 @@ def make_map():
        conditions={'function':not_in_sr},
        requirements={'page':'privacypolicy|useragreement'})
 
+    mc('/wiki/create', controller='wiki', action='wiki_new')
     mc('/wiki/create/*page', controller='wiki', action='wiki_create')
     mc('/wiki/edit/*page', controller='wiki', action='wiki_revise')
     mc('/wiki/revisions', controller='wiki', action='wiki_recent')

--- a/r2/r2/controllers/wiki.py
+++ b/r2/r2/controllers/wiki.py
@@ -59,7 +59,7 @@ from r2.controllers.api_docs import api_doc, api_section
 from r2.lib.pages.wiki import (WikiPageView, WikiNotFound, WikiRevisions,
                               WikiEdit, WikiSettings, WikiRecent,
                               WikiListing, WikiDiscussions,
-                              WikiCreate)
+                              WikiCreate, WikiNew, WikiBasePage)
 
 from r2.config.extensions import set_extension
 from r2.lib.template_helpers import add_sr
@@ -166,6 +166,16 @@ class WikiController(RedditController):
                                       wrap=default_thing_wrapper())
         listing = WikiRevisionListing(builder).listing()
         return WikiRevisions(listing, page=page.name, may_revise=this_may_revise(page)).render()
+
+    def GET_wiki_new(self):
+        is_api = c.render_style in extensions.API_TYPES
+        if not this_may_revise():
+            if not is_api:
+                error = _("You do not have sufficient perrmissions to create wiki pages in this subreddit.")
+                errorpage = WikiBasePage(error, page=_("sorry :("), actionless=True)
+                request.environ['usable_error_content'] = errorpage.render()
+            self.abort403()
+        return WikiNew().render()
 
     @validate(wp=VWikiPageRevise('page'),
               page=VWikiPageName('page'))

--- a/r2/r2/lib/menus.py
+++ b/r2/r2/lib/menus.py
@@ -132,7 +132,7 @@ menu =   MenuHandler(hot          = _('hot'),
                      
                      wikibanned        = _("ban wiki contributors"),
                      wikicontributors  = _("add wiki contributors"),
-                     
+                     wikicreate        = _("add a new wiki page"),
                      wikirecentrevisions = _("recent wiki revisions"),
                      wikipageslist = _("wiki page list"),
 

--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -283,7 +283,11 @@ class Reddit(Templated):
     def wiki_actions_menu(self, moderator=False):
         buttons = []
 
-        buttons.append(NamedButton("wikirecentrevisions",
+        buttons.append(NamedButton("wikicreate", 
+                                   css_class='reddit-edit',
+                                   dest="/wiki/create"))
+ 
+        buttons.append(NamedButton("wikirecentrevisions", 
                                    css_class="wikiaction-revisions",
                                    dest="/wiki/revisions"))
 

--- a/r2/r2/lib/pages/wiki.py
+++ b/r2/r2/lib/pages/wiki.py
@@ -53,6 +53,11 @@ class WikiPageNotFound(Templated):
         self.base_url = c.wiki_base_url
         Templated.__init__(self)
 
+class WikiNewPage(Templated):
+    def __init__(self):
+        self.base_url = c.wiki_base_url
+        Templated.__init__(self)
+
 class WikiPageListing(Templated):
     def __init__(self, pages, linear_pages, page=None):
         self.pages = pages
@@ -156,6 +161,13 @@ class WikiNotFound(WikiBasePage):
         content = WikiPageNotFound(page)
         context['alert'] = _("page %s does not exist in this subreddit") % page
         context['actionless'] = True
+        WikiBasePage.__init__(self, content, page=page, **context)
+
+class WikiNew(WikiBasePage):
+    def __init__(self, **context):
+        content = WikiNewPage()
+        context['actionless'] = True
+        page = _("create a wiki page")
         WikiBasePage.__init__(self, content, page=page, **context)
 
 class WikiCreate(WikiBasePage):

--- a/r2/r2/public/static/css/wiki.less
+++ b/r2/r2/public/static/css/wiki.less
@@ -12,6 +12,17 @@
         margin: 15px;
         margin-right: 325px;
 
+        .wikicreate {
+            input {
+                width: 410px;
+                margin-top: 5px;
+            }
+            button {
+                margin-left: 10px;
+                font-size: 100%;
+            }
+        }
+
         // Wiki page listing 
         .pagelisting {
             font-size: 1.2em;

--- a/r2/r2/public/static/js/wiki.js
+++ b/r2/r2/public/static/js/wiki.js
@@ -150,6 +150,34 @@ r.wiki = {
 
     helpoff: function(elem) {
         $(elem).parents("form").children(".markhelp:first").hide();
-    }
+    },
 
+    create: function(event) {
+        event.preventDefault()
+        var $this = $(event.target),
+            page = r.utils.serializeForm($this).page,
+            url = r.wiki.baseUrl() + '/create/' + encodeURIComponent(page),
+            button = $this.find("button").last(),
+            status = $this.find(".error").first()
+        status.text("")
+        $this.addClass("working")
+        button.attr("disabled", true)
+        $.ajax({
+            url: url + ".json",
+            type: 'GET',
+            dataType: 'json',
+            error: function(xhr) {
+                if(xhr.status == 404) {
+                    window.location = url
+                } else {
+                    $this.removeClass("working")
+                    button.removeAttr("disabled")
+                    status.text(r._("invalid wiki page name"))
+                }
+            },
+            success: function() {
+                window.location = url
+            }
+        })
+    }
 }

--- a/r2/r2/templates/wikinewpage.html
+++ b/r2/r2/templates/wikinewpage.html
@@ -1,0 +1,31 @@
+## The contents of this file are subject to the Common Public Attribution
+## License Version 1.0. (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License at
+## http://code.reddit.com/LICENSE. The License is based on the Mozilla Public
+## License Version 1.1, but Sections 14 and 15 have been added to cover use of
+## software over a computer network and provide for limited attribution for the
+## Original Developer. In addition, Exhibit A has been modified to be
+## consistent with Exhibit B.
+##
+## Software distributed under the License is distributed on an "AS IS" basis,
+## WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+## the specific language governing rights and limitations under the License.
+##
+## The Original Code is reddit.
+##
+## The Original Developer is the Initial Developer.  The Initial Developer of
+## the Original Code is reddit Inc.
+##
+## All portions of the code written by reddit are Copyright (c) 2006-2013
+## reddit Inc. All Rights Reserved.
+###############################################################################
+
+<form onsubmit="return r.wiki.create(event)" class="wikicreate roundfield linefield usertext">
+    <span class="title">create wiki page</span>
+    <span class="gray">pick a page name to begin<span class="throbber"></span></span>
+    <div class="linefield-content">
+        <div class="error"></div>
+        <input type="text" name="page" placeholder="${_('new page name')}">
+        <button>${_('create')}</button>
+    </div>
+</form>


### PR DESCRIPTION
Some users would like a page to assist in creating wiki pages.  Currently a user must visit the url for the page manually in order to create it.  Some users find this confusing as it is not obvious how to create a page.  This pull requests adds such a page.
