### PR TITLE
jsonp: Ensure jsonp responds with application/javascript.

### DIFF
--- a/r2/r2/controllers/reddit_base.py
+++ b/r2/r2/controllers/reddit_base.py
@@ -433,6 +433,7 @@ def set_content_type():
         c.allowed_callback = callback
         c.user = UnloggedUser(get_browser_langs())
         c.user_is_loggedin = False
+        response.content_type = "application/javascript"
 
 def get_browser_langs():
     browser_langs = []


### PR DESCRIPTION
Allows browsers with higher security restrictions (IE with security level set to high) to accept our jsonp properly.  This is a much more correct Content-Type as jsonp is is indeed not json.

Was likely that way before simply because jsonp was tacked onto the json code.

Fixes #811
