### PR TITLE
Fix og:image being detected

### DIFF
--- a/r2/r2/lib/scraper.py
+++ b/r2/r2/lib/scraper.py
@@ -201,7 +201,7 @@ class Scraper:
         max_url = None
 
         if self.soup:
-            og_image = self.soup.find('meta', property='og:image')
+            og_image = self.soup.find('meta', attrs={'property': 'og:image'}) or self.soup.find('meta', attrs={'name': 'og:image'})
             if og_image and og_image['content']:
                 log.debug("Using og:image")
                 return og_image['content']


### PR DESCRIPTION
For some reason, this code was using `property=` to match the tag, but that’s incorrect:

```
>>> text = "<html><meta name=\"og:image\" content=\"text.png\" /></html>"
>>> import BeautifulSoup
>>> soup = BeautifulSoup.BeautifulSoup(text)
>>> soup.find('meta')
<meta name="og:image" content="text.png" />
>>> soup.find('meta', property='og:image')
>>> soup.find('meta', attrs={'name':'og:image'})
<meta name="og:image" content="text.png" />
```
