### PR TITLE
wiki: Ensure wiki_edit_age is forwarded in the Frontpage.

### DIFF
--- a/r2/r2/models/subreddit.py
+++ b/r2/r2/models/subreddit.py
@@ -1142,7 +1142,11 @@ class DefaultSR(_DefaultSR):
     @property
     def wiki_edit_karma(self):
         return self._base.wiki_edit_karma
-    
+
+    @property
+    def wiki_edit_age(self):
+        return self._base.wiki_edit_age
+
     def is_wikicontributor(self, user):
         return self._base.is_wikicontributor(user)
     


### PR DESCRIPTION
The Frontpage was getting a min edit age from the defaults set as it was not forwarded from _base.
