### PR TITLE
site_admin API query variable inconsistency

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -1706,7 +1706,7 @@ class ApiController(RedditController, OAuth2ResourceController):
                    sr = VByName('sr'),
                    name = VSubredditName("name"),
                    title = VLength("title", max_length = 100),
-                   header_title = VLength("header-title", max_length = 500),
+                   header_title = VLength("header_title", max_length = 500),
                    domain = VCnameDomain("domain"),
                    public_description = VMarkdown("public_description", max_length = 500),
                    prev_public_description_id = VLength('prev_public_description_id', max_length = 36),


### PR DESCRIPTION
http://www.reddit.com/dev/api#POST_api_site_admin has an inconsistency in the naming.

"header-title" uses a hyphen when _everything else_ uses an underscore. Even then json returned from http://www.reddit.com/r/SR_NAME/about.json is "header_title".
