### PR TITLE
moderation: Add missing modaction text for description field.

### DIFF
--- a/r2/r2/models/wiki.py
+++ b/r2/r2/models/wiki.py
@@ -53,7 +53,8 @@ special_pages = ('config/stylesheet', 'config/sidebar', 'config/description')
 # Pages which have a special length restrictions (In bytes)
 special_length_restrictions_bytes = {'config/stylesheet': 128*1024, 'config/sidebar': 5120, 'config/description': 500}
 
-modactions = {'config/sidebar': "Updated subreddit sidebar"}
+modactions = {'config/sidebar': "Updated subreddit sidebar",
+              'config/description': "Updated subreddit description"}
 
 # Page "index" in the subreddit "reddit.com" and a seperator of "\t" becomes:
 #   "reddit.com\tindex"


### PR DESCRIPTION
Currently, when description is updated via the subreddit settings, it just gives a modaction of wiki page updated with no description.  This pull request adds the missing description for this page.  Stylesheet does not need one as it uses different logic to update the field.
