### PR TITLE
messages: Fix dest username leak on deleted users.

### DIFF
--- a/r2/r2/models/link.py
+++ b/r2/r2/models/link.py
@@ -1419,7 +1419,13 @@ class Message(Thing, Printable):
             else:
                 taglinetext = _("to %(dest)s from %(author)s sent %(when)s ago")
             item.taglinetext = taglinetext
-            item.dest = item.to.name if item.to else ""
+            if item.to:
+                if item.to._deleted:
+                    item.dest = "[deleted]"
+                else:
+                    item.dest = item.to.name
+            else:
+                item.dest = ""
             if item.sr_id:
                 if item.hide_author:
                     item.updated_author = _("via %(subreddit)s")


### PR DESCRIPTION
Fixes usernames appearing for deleted users in the "to" text on messages.

Reported by http://www.reddit.com/r/bugs/comments/1hpsk7/username_not_shown_as_deleted_if_the_account_is/
