### PR TITLE
recentlinks: Correct link flair class.

### DIFF
--- a/r2/r2/templates/link.htmllite
+++ b/r2/r2/templates/link.htmllite
@@ -30,7 +30,7 @@
 
 <%def name="flair()">
   %if c.user.pref_show_link_flair:
-    <span class="linkflair"
+    <span class="linkflairlabel"
         ${optionalstyle("color: #545454; background-color: #f5f5f5; border: 1px solid #dedede; display: inline-block; font-size: x-small; margin-right: 0.5em; padding: 0 2px; max-width: 10em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;")}>
       ${thing.flair_text}
     </span>


### PR DESCRIPTION
Link flair on "recently viewed links" was showing up with no grey background and oddly placed.  Corrected the class name to linkflairlabel.
