### PR TITLE
When submitting a comment, validate it as selftext (same as when editing)

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -1167,7 +1167,7 @@ class ApiController(RedditController, OAuth2ResourceController):
                               prefix = "rate_comment_"),
                    ip = ValidIP(),
                    parent = VSubmitParent(['thing_id', 'parent']),
-                   comment = VMarkdown(['text', 'comment']))
+                   comment = VSelfText(['text', 'comment']))
     @api_doc(api_section.links_and_comments)
     def POST_comment(self, commentform, jquery, parent, comment, ip):
         """Submit a new comment or reply to a message.


### PR DESCRIPTION
When a user submits a comment, it is [validated as `VMarkdown`](https://github.com/reddit/reddit/blob/3bfe0a2513495f8e667f60ca3efce03f97990e51/r2/r2/controllers/api.py#L1234), which allows [`max_length = 10000` characters](https://github.com/reddit/reddit/blob/3bfe0a2513495f8e667f60ca3efce03f97990e51/r2/r2/lib/validator/validator.py#L574).  However, when a user _edits_ a self-post or comment, it is [validated as `VSelfText`](https://github.com/reddit/reddit/blob/3bfe0a2513495f8e667f60ca3efce03f97990e51/r2/r2/controllers/api.py#L1184), which allows [`get_max_length: return self.max_length * 1.5` or 15000 characters]().

---

It looks like the `POST_comment` validator didn't get updated properly a while ago, but the discrepancy went unnoticed until self-text max_length was extended.
- 2010-05-17: [`POST_comment`](https://github.com/reddit/reddit/commit/a402d48d#L6L604) and [`POST_editusertext`](https://github.com/reddit/reddit/commit/a402d48d#L6L570) now validate as `VMarkdown`.
- 2010-10-18:  [`POST_editusertext`](https://github.com/reddit/reddit/commit/37e2ba98/#L5L726) now validates as `VSelfText`, but [`POST_comment`](https://github.com/reddit/reddit/blob/37e2ba9892d1742f78ab496d8fc1d17797731078/r2/r2/controllers/api.py#L773) still validates as `VMarkdown`
- 2012-09-05: [`VSelfText` now has a larger max_length](https://github.com/reddit/reddit/commit/a3274399) than `VMarkdown`, which means posting comments gets different validation than editing them.
