### PR TITLE
wiki: Only show infobar once.

### DIFF
--- a/r2/r2/lib/pages/wiki.py
+++ b/r2/r2/lib/pages/wiki.py
@@ -138,6 +138,9 @@ class WikiBasePage(Reddit):
                         show_wiki_actions=True, page_classes=page_classes,
                         content=content, **context)
 
+    def content(self):
+        return self._content
+
 class WikiPageView(WikiBasePage):
     def __init__(self, content, page, diff=None, renderer='wiki', **context):
         may_revise = context.get('may_revise')


### PR DESCRIPTION
Two infobars were showing up.  Removed that inforbar as I want the wiki infobar to display above all the wiki toolbars and such.  The other infobar is displayed via wikibasepage.html.
