### PR TITLE
Escaping percentage signs in gettext strings

### DIFF
--- a/r2/r2/templates/goldpartnerspage.html
+++ b/r2/r2/templates/goldpartnerspage.html
@@ -69,20 +69,20 @@
                    button_dest='claim')}
 
     ${partner_item('bartsbakery',
-                   _("Claim your code below, then enter it as a Coupon code in your cart at http://bartsbakery.com to get 20% off any product."),
+                   _("Claim your code below, then enter it as a Coupon code in your cart at http://bartsbakery.com to get 20%% off any product."),
                    static('gold/partner-bartsbakery.png'), 
                    img_url='http://bartsbakery.com',
                    description_md=_("# Bart's Bakery Chocolate Chip Cookies\n"
-                                    'Cookies. Really good cookies. 20% off any product.'),
+                                    'Cookies. Really good cookies. 20%% off any product.'),
                    extra_class='new',
                    button_dest='claim')}
 
     ${partner_item('betabrand',
-                   _("Claim your code below, then enter it as a Gift code in your cart at http://betabrand.com to get 20% off."),
+                   _("Claim your code below, then enter it as a Gift code in your cart at http://betabrand.com to get 20%% off."),
                    static('gold/partner-betabrand.png'), 
                    img_url='http://betabrand.com',
                    description_md=_('# Betabrand Unique Online Fashions\n'
-                                    'Presently Pantless? Get 20% off any item in our collection.'),
+                                    'Presently Pantless? Get 20%% off any item in our collection.'),
                    extra_class='new',
                    button_dest='claim')}
 
@@ -91,7 +91,7 @@
                    static('gold/partner-empiremayo.png'),
                    img_url='http://empiremayo.com',
                    description_md=_('# Empire Mayonnaise\n'
-                                    'Exquisite mayonnaises. 15% discount (two uses per customer).'),
+                                    'Exquisite mayonnaises. 15%% discount (two uses per customer).'),
                    button_dest='claim')}
 
     ${partner_item('goldbely',
@@ -117,7 +117,7 @@
                    static('gold/partner-outgrowme.png'),
                    img_url='http://outgrow.me/gold',
                    description_md=_('# Outgrow.me Marketplace\n'
-                                    'Successful crowd-funded items. 15% discount.'),
+                                    'Successful crowd-funded items. 15%% discount.'),
                    extra_class='new',
                    button_dest='claim')}
 


### PR DESCRIPTION
Percentage signs are being interpreted by Transifex as string markers and we're getting errors when translating them (`The expression '% o' is not present in the translation`). AFAIK escaping them as `%%` _should_ solve this.
