### PR TITLE
Smoother listing open/close animation

### DIFF
--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -7095,6 +7095,8 @@ body.with-listing-chooser {
 
     & > .content, & .footer-parent {
         margin-left: 140px + @lc-grippy-width;
+
+        .transition(margin-left, .25s);
     }
 
     .listing-chooser {


### PR DESCRIPTION
Currently, listing-chooser has an transition, but content doesn't, so opening and closing listing chooser looks kinda weird. Adding transition on content makes it smoother.
