### PR TITLE
Change sorts to precompute more confidence intervals

### DIFF
--- a/r2/r2/lib/db/_sorts.pyx
+++ b/r2/r2/lib/db/_sorts.pyx
@@ -76,7 +76,7 @@ cpdef double _confidence(int ups, int downs):
 
     return (left - right) / under
 
-cdef int up_range = 400
+cdef int up_range = 1500
 cdef int down_range = 100
 cdef list _confidences = []
 for ups in xrange(up_range):


### PR DESCRIPTION
When we wrote this precomputation comment scores rarely exceeded 400 pints.  They get much higher now.

This change would increase the performance of reddit at the cost of a small increase in startup time.
