### PR TITLE
Remove forced margin between wiki and sidebar

### DIFF
--- a/r2/r2/public/static/css/wiki.less
+++ b/r2/r2/public/static/css/wiki.less
@@ -10,7 +10,6 @@
     // Main content portion of the wiki pages
     .wiki-page-content {
         margin: 15px;
-        margin-right: 325px;
 
         // Wiki page listing 
         .pagelisting {

--- a/r2/r2/public/static/css/wiki.less
+++ b/r2/r2/public/static/css/wiki.less
@@ -223,3 +223,7 @@
         float: right;
     }
 }
+// add margin between wiki and sidebar
+.wiki-page .side {
+    margin-left: 15px;
+}

--- a/r2/r2/public/static/css/wiki.less
+++ b/r2/r2/public/static/css/wiki.less
@@ -225,5 +225,5 @@
 }
 // add margin between wiki and sidebar
 .wiki-page .side {
-    margin-left: 15px;
+    margin-left: 20px;
 }


### PR DESCRIPTION
Currently, the wiki content is given a margin with the sidebar using a right margin of 325px. This value will always depend on the sidebar's width.

Since the rest of Reddit's content flows with the sidebar this element should use the same behaviour. This way, the wiki maintains a margin, but doesn't use that huge margin value.

To test the benefits: delete the sidebar node in a current default wiki page. The wiki will maintain that huge space on the right unnecessarily.