### PR TITLE
Fix very minor wording error

### DIFF
--- a/r2/r2/templates/optout.html
+++ b/r2/r2/templates/optout.html
@@ -27,7 +27,7 @@
     ${_("The address '%(email)s' will no longer receive email from us.") % dict(email=thing.email)}
   </p>
   <p>
-     ${_("A confirmation email has been queued up and should be reaching you shortly.  It will be the last you hear of us.")}
+     ${_("A confirmation email has been queued up and should be reaching you shortly.  It will be the last you hear from us.")}
    </p>
   %else:
    <p>


### PR DESCRIPTION
Made a small change to the wording on the e-mail opt-out page.
