### PR TITLE
always allow "unvoting" on things, regardless of age

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -1529,7 +1529,7 @@ class ApiController(RedditController, OAuth2ResourceController):
             store = False
 
         thing_age = c.start_time - thing._date
-        if thing_age.days > g.VOTE_AGE_LIMIT:
+        if thing_age.days > g.VOTE_AGE_LIMIT and dir != 0:
             g.log.debug("ignoring vote on old thing %s" % thing._fullname)
             store = False
 


### PR DESCRIPTION
Preventing upvotes or downvotes for old items makes sense, but users should be allowed to remove votes they've previously cast if they're determined to (which would require directly submitting to the API, no UI changes here).