### PR TITLE
Added help text for stickying posts in linkcommentssettings.html

### DIFF
--- a/r2/r2/templates/linkcommentssettings.html
+++ b/r2/r2/templates/linkcommentssettings.html
@@ -47,4 +47,9 @@
       question=_("sticky this? (any existing sticky will be replaced)"),
       hidden_data=dict(id=thing.link._fullname, state=True))}
   %endif
+  
+%if thing.can_edit and thing.link.is_self:
+  &nbsp;<span class="help-hoverable" title="${_('stickying this post will make it stay visible at the top of your reddit's hot page. It will display normally outside of your reddit.)}">(?)</span>
+%endif
+
 %endif

--- a/r2/r2/templates/linkcommentssettings.html
+++ b/r2/r2/templates/linkcommentssettings.html
@@ -49,6 +49,6 @@
   %endif
 
 %if thing.can_edit and thing.link.is_self:
-  &nbsp;<span class="help-hoverable" title="stickying this post will make it visible at the top of your reddit's top listing. it will appear normally outside of your reddit.">(?)</span>
+  &nbsp;<span class="help-hoverable" title="stickying this post will make it visible at the top of your subreddit's top listing. it will appear normally outside of your subreddit.">(?)</span>
 %endif
 %endif

--- a/r2/r2/templates/linkcommentssettings.html
+++ b/r2/r2/templates/linkcommentssettings.html
@@ -47,9 +47,8 @@
       question=_("sticky this? (any existing sticky will be replaced)"),
       hidden_data=dict(id=thing.link._fullname, state=True))}
   %endif
-  
-%if thing.can_edit and thing.link.is_self:
-  &nbsp;<span class="help-hoverable" title="${_('stickying this post will make it stay visible at the top of your reddit's hot page. It will display normally outside of your reddit.)}">(?)</span>
-%endif
 
+%if thing.can_edit and thing.link.is_self:
+  &nbsp;<span class="help-hoverable" title="stickying this post will make it visible at the top of your reddit's top listing. it will appear normally outside of your reddit.">(?)</span>
+%endif
 %endif


### PR DESCRIPTION
This change adds a help text visible to moderators for "sticky this post" in the same way that contest mode has. It does not appear for users who don't have the ability to sticky the post in the first place, of course. :) All for the sake of congruency and on-page documentation!

![sticky-help](https://f.cloud.github.com/assets/4652603/1030950/3892f5d0-0ecb-11e3-9002-a953af364dfe.jpg)
