### PR TITLE
Add 'allowfullscreen' attribute to expando media embeds so html5 youtube videos can go full screen.

### DIFF
--- a/r2/r2/templates/mediaembed.html
+++ b/r2/r2/templates/mediaembed.html
@@ -26,4 +26,5 @@
 <iframe src="http://${thing.media_domain}/mediaembed/${thing.id36}"
         id="media-embed-${thing.id36}-${randstr(3)}" class="media-embed"
         width="${thing.width}" height="${thing.height}" border="0"
-        frameBorder="0" scrolling="${'auto' if thing.scrolling else 'no'}"></iframe>
+        frameBorder="0" scrolling="${'auto' if thing.scrolling else 'no'}"
+        allowfullscreen></iframe>


### PR DESCRIPTION
TL;DR: Minor frontend bug / annoyance with HTML5 Youtube links in expando. HTML5 Youtube embeds are missing the fullscreen button. I added an attribute "allowfullscreen" to the iframe, and now it works! Yay!

To reproduce:
1. Go to http://www.youtube.com/html5, enable html5 videos
2. Click expando on any youtube video on reddit
3. Note the missing fullscreen button in the embedded player

In order to allow embedded html5 youtube videos to have a fullscreen option in expando, the containing iframe needs to have attribute "allowfullscreen".

See [W3C Fullscreen Specifications, Section 7: Security and Privacy Considerations](https://dvcs.w3.org/hg/fullscreen/raw-file/tip/Overview.html#security-and-privacy-considerations):

> To prevent embedded content from going fullscreen only embedded content specifically allowed via the allowfullscreen attribute of the HTML iframe element will be able to go fullscreen. This prevents untrusted content from going fullscreen.

Proof that this fix works: http://imgur.com/a/pM13I
