### PR TITLE
multis: Disable multi showcase subreddit by default.

### DIFF
--- a/r2/example.ini
+++ b/r2/example.ini
@@ -622,4 +622,4 @@ listing_chooser_sample_multis = /user/reddit/m/hello, /user/reddit/m/world
 # multi of subreddits to share with gold users
 listing_chooser_gold_multi = /user/reddit/m/gold
 # subreddit showcasing new multireddits
-listing_chooser_explore_sr = multis
+listing_chooser_explore_sr = 


### PR DESCRIPTION
reddit installs without a subreddit called multis raise exceptions for logged in users.  Avoid this by disabling the showcase subreddit in the example.ini by default.
