### PR TITLE
compact.scss: .cover is displayed over the whole screen.

### DIFF
--- a/r2/r2/public/static/css/compact.css
+++ b/r2/r2/public/static/css/compact.css
@@ -438,7 +438,7 @@ body.toolbar { margin: 0px; padding: 0px; overflow: hidden; }
 
 .clearleft { clear: left; }
 
-.cover { position: absolute; left: 0px; top: 0px; width: 100%; height: 100%; background-color: gray; opacity: .3; z-index: 1000; }
+.cover { position: fixed; left: 0px; top: 0px; width: 100%; height: 100%; background-color: gray; opacity: .3; z-index: 1000; }
 
 .popup { position: absolute; top: 75px; left: 0; -webkit-border-radius: 30px; -moz-border-radius: 30px; -ms-border-radius: 30px; -o-border-radius: 30px; border-radius: 30px; background-color: white; text-align: left; z-index: 1001; padding: 10px; border-color: #B2B2B2 black black #B2B2B2; border-style: solid; border-width: 1px; margin-left: auto; margin-right: auto; max-width: 350px; }
 

--- a/r2/r2/public/static/css/compact.scss
+++ b/r2/r2/public/static/css/compact.scss
@@ -1287,7 +1287,7 @@ body.toolbar {
 }
 
 .cover {
-    position: absolute;
+    position: fixed;
     left: 0px;
     top: 0px; 
     width: 100%;


### PR DESCRIPTION
This patch should fix a problem with element with cover class not being displayed on i.reddit.com. Because the cover is not displayed, the login popup cannot be closed without logging in.

I have not tested this patch except by faking it in Firebug in Firefox (I don't have the time at the moment to setup the development environment).
