### PR TITLE
get_title: Fixed a bug if the <head> isn't in the first 1kb.

### DIFF
--- a/r2/r2/lib/utils/utils.py
+++ b/r2/r2/lib/utils/utils.py
@@ -225,7 +225,7 @@ def get_title(url):
 def extract_title(data):
     """Tries to extract the value of the title element from a string of HTML"""
     bs = BeautifulSoup(data, convertEntities=BeautifulSoup.HTML_ENTITIES)
-    if not bs:
+    if not bs or not bs.html.head:
         return
 
     title_bs = bs.html.head.title


### PR DESCRIPTION
This fixes a bug if the head tag doesn't appear in the first 1kb of the fetched markup.  Without this an exception is thrown and the subsequent call to grab 10kb of the document is never reached.

For a bit more information:
The exception that is thrown is an AttributeError ('NoneType' object has no attribute 'head') on https://github.com/reddit/reddit/blob/master/r2/r2/lib/utils/utils.py#L231

You can test this against http://stecktest.tumblr.com/post/62722947715
