### PR TITLE
Remove explicit height on .subtoolbar and fix background on selected menu item.

### DIFF
--- a/r2/r2/public/static/css/compact.scss
+++ b/r2/r2/public/static/css/compact.scss
@@ -479,7 +479,7 @@ body[orient="landscape"] > #topbar > h1 {
     @include vertical_gradient(#ddd, #aaa);
     @include border-radius(8px);
     border: 1px solid #aaa;
-    padding-top: 2px; 
+    padding-top: 1px; 
     padding-bottom: 1px; 
     @include box-shadow(0px 1px 1px rgba(255,255,255,.8));
 }

--- a/r2/r2/public/static/css/compact.scss
+++ b/r2/r2/public/static/css/compact.scss
@@ -450,7 +450,6 @@ body[orient="landscape"] > #topbar > h1 {
 /*Subtoolbar (eg hot)*/
 .subtoolbar {
     @include box-sizing(border-box);
-    height: 32px;
     @include vertical_gradient(white, #ccc);
     border-bottom: 1px solid #bbb;
     padding: 6px;


### PR DESCRIPTION
With a fixed height on .subtoolbar menu items disappear on iPods, iPhones etc. (all devices narrower than 444px).
Browsers display it jsut fine without the height set.

I also changed a padding by one pixel, which makes the circular background fit inside the container and not be cut off.

![pullrequest](https://f.cloud.github.com/assets/3637499/1345643/f1bb776e-3692-11e3-8ea2-45de1314b1ab.png)
