### PR TITLE
Disable Google Checkout for gilding via purchase-gold page.

### DIFF
--- a/r2/r2/templates/goldpayment.html
+++ b/r2/r2/templates/goldpayment.html
@@ -53,7 +53,7 @@
     %else:
       <p>${_("Please select a payment method.")}</p>
 
-      %if thing.google_id and (not thing.clone_template or thing.comment):
+      %if thing.google_id and not (thing.clone_template or thing.comment):
         ## disable google wallet for gilding
         ${self.google_button()}
       %endif


### PR DESCRIPTION
Follow up to commit 399f0c6 which intended to disable Google Checkout for gilding comments.

The above commit succeeded for the gold form that is injected into the DOM when a user clicks the 'give gold' button, however if the user follows the link's href to the purchase-gold page (`https://ssl.reddit.com/gold?goldtype=gift&months=1&comment=<comment ref>`) the Google Checkout button is rendered.  This pull request corrects that.
