### PR TITLE
Added gzip support to the scraper

### DIFF
--- a/r2/r2/lib/media.py
+++ b/r2/r2/lib/media.py
@@ -139,7 +139,7 @@ def _fetch_url(url, referer=None):
         return None, None
     response = urllib2.urlopen(request)
     response_data = response.read()
-    if response.info().get("Content-Encoding").lower() == "gzip":
+    if response.info().get("Content-Encoding").lower() in ["gzip", "x-gzip"]:
         buf = cStringIO.StringIO(response_data)
         f = gzip.GzipFile(fileobj=buf)
         response_data = f.read()


### PR DESCRIPTION
Helpful because Amazon S3 doesn't support switching between gzipped and non-gzipped content so often times resources are uploaded directly gzipped with gzipped headers. Because all modern browsers support gzip, S3 always serves gzip and it's not generally a problem. Urllib, however, doesn't support gzip so gzipped resource currently fail to decode when scraped.
