### PR TITLE
Default CSS3 image-orientation to from-image

### DIFF
--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -86,6 +86,10 @@ a:active { border: 0 none;}
 a:focus { -moz-outline-style: none; }
 */
 
+img {
+    image-orientation: from-image;
+}
+
 .rounded {
     border-radius: 7px;
 }


### PR DESCRIPTION
With this change, [`image-orientation`](https://developer.mozilla.org/en-US/docs/Web/CSS/image-orientation) will now rotate an image based on its EXIF information in Firefox.
