### PR TITLE
Add "required" attribute to usertext text areas

### DIFF
--- a/r2/r2/templates/usertext.compact
+++ b/r2/r2/templates/usertext.compact
@@ -67,6 +67,7 @@
       <div>
         <textarea rows="1" cols="1"
                   name="${thing.name}"
+                  required
                   >${keep_space(thing.text)}</textarea>
       </div>
 

--- a/r2/r2/templates/usertext.html
+++ b/r2/r2/templates/usertext.html
@@ -139,6 +139,7 @@
         <textarea rows="1" cols="1"
                   name="${thing.name}"
                   class="${thing.textarea_class}"
+                  required
                   >${keep_space(thing.text)}</textarea>
       </div>
 


### PR DESCRIPTION
This opens up some additional options for subreddits to style comment areas. The `:valid` and `:invalid` selectors can then be used to apply rules that depend on whether or not text is entered into the field.

This can help the implementation of one common pattern that puts subreddit rules inside comment areas as a background image, and hides them when the field is selected. Many subreddits (eg. /r/nosleep, /r/circlebroke, /r/cringe) currently use this pattern, but at the moment, if the user tabs away from the field after entering text, the background image pops back up again. Adding in this `required` attribute allows CSS authors to detect this case and work around it, again through the `:valid` and `:invalid` selectors.

This addition also makes semantic sense, as these fields do indeed require input in order for the form to be submitted.