### PR TITLE
lib/strings.py: Fix a misspelling

### DIFF
--- a/r2/r2/lib/strings.py
+++ b/r2/r2/lib/strings.py
@@ -50,16 +50,16 @@ string_dict = dict(
     
     submitting = _("submitting..."),
 
-    # this accomodates asian languages which don't use spaces
+    # this accommodates asian languages which don't use spaces
     number_label = _("%(num)d %(thing)s"),
 
-    # this accomodates asian languages which don't use spaces
+    # this accommodates asian languages which don't use spaces
     points_label = _("%(num)d %(point)s"),
 
-    # this accomodates asian languages which don't use spaces
+    # this accommodates asian languages which don't use spaces
     time_label = _("%(num)d %(time)s"),
 
-    # this accomodates asian languages which don't use spaces
+    # this accommodates asian languages which don't use spaces
     float_label = _("%(num)5.3f %(thing)s"),
 
     # this is for Japanese which treats people counts differently


### PR DESCRIPTION
It must be 'accommodates' not 'accomodates'. I know nobody can see it unless (s)he looks at the source code but, anyway. =)
