### PR TITLE
It's worth a shot.

### DIFF
--- a/r2/r2/models/wiki.py
+++ b/r2/r2/models/wiki.py
@@ -51,14 +51,16 @@ restricted_namespaces = ('reddit/', 'config/', 'special/')
 
 # Pages which may only be edited by mods, must be within restricted namespaces
 special_pages = ('config/stylesheet', 'config/sidebar',
-                 'config/submit_text', 'config/description')
+                 'config/submit_text', 'config/description',
+                 '/usernotes')
 
 # Pages which have a special length restrictions (In bytes)
 special_length_restrictions_bytes = {
     'config/stylesheet': 128*1024,
     'config/submit_text': 1024,
     'config/sidebar': 5120,
-    'config/description': 500
+    'config/description': 500,
+    'usernotes': 1024*1024
 }
 
 modactions = {'config/sidebar': "Updated subreddit sidebar",


### PR DESCRIPTION
I realize this is requesting special treatment for a third-party tool.  But it seems much simpler than spamming the wiki with /usernotes /usernotes1 /userneotes2 and three get requests for every sub.  

FWIW, toolbox, on it's end, caches usernotes for 15 minutes, per sub.  So one larger get seems better than three smaller one.
