### PR TITLE
Updating copyright to 2014 and fixing link to logo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -487,12 +487,12 @@ The Original Code is reddit.
 The Original Developer is the Initial Developer.  The Initial Developer of the
 Original Code is reddit Inc.
 
-All portions of the code written by reddit are Copyright (c) 2006-2013
+All portions of the code written by reddit are Copyright (c) 2006-2014
 reddit Inc. All Rights Reserved.
 
 EXHIBIT B. Attribution Information
 
-Attribution Copyright Notice: Copyright (c) 2006-2013 reddit Inc. All Rights
+Attribution Copyright Notice: Copyright (c) 2006-2014 reddit Inc. All Rights
 Reserved.
 
 Attribution Phrase (not exceeding 10 words): Powered by reddit
@@ -500,7 +500,7 @@ Attribution Phrase (not exceeding 10 words): Powered by reddit
 Attribution URL: http://code.reddit.com
 
 Graphic Image as provided in the Covered Code:
-http://code.reddit.com/reddit_logo.png
+http://www.redditstatic.com/about/assets/reddit-logo.png
 
 Display of Attribution Information is required in Larger Works which are defined
 in the CPAL as a work which combines Covered Code or portions thereof with code


### PR DESCRIPTION
Updating copyright year from 2013 to 2014 and fixing broken link to reddit-logo.png
