### PR TITLE
Added missing period

### DIFF
--- a/r2/r2/lib/strings.py
+++ b/r2/r2/lib/strings.py
@@ -87,7 +87,7 @@ string_dict = dict(
 
     sr_messages = dict(
         empty =  _('you have not subscribed to any subreddits.'),
-        subscriber =  _('below are the subreddits you have subscribed to'),
+        subscriber =  _('below are the subreddits you have subscribed to.'),
         contributor =  _('below are the subreddits that you are an approved submitter on.'),
         moderator = _('below are the subreddits that you have moderator access to.')
         ),


### PR DESCRIPTION
Following the style of `contributor` and `moderator` messages, the `subscriber` message should also have a period at the end.
