### PR TITLE
Fix docs for multi rename and copy

### DIFF
--- a/r2/r2/controllers/multi.py
+++ b/r2/r2/controllers/multi.py
@@ -232,7 +232,7 @@ class MultiApiController(RedditController):
     )
     @api_doc(
         api_section.multis,
-        uri="/api/multi/{multipath}/copy",
+        uri="/api/multi/copy",
     )
     def POST_multi_copy(self, from_multi, to_path_info):
         """Copy a multi.
@@ -267,7 +267,7 @@ class MultiApiController(RedditController):
     )
     @api_doc(
         api_section.multis,
-        uri="/api/multi/{multipath}/rename",
+        uri="/api/multi/rename",
     )
     def POST_multi_rename(self, from_multi, to_path_info):
         """Rename a multi."""


### PR DESCRIPTION
The API paths for copying and renaming multis are listed as "/api/multi/{multipath}/(copy/rename)", when they are actually "/api/multi/(copy/rename)". This pull request fixes the documentation for these methods.