### PR TITLE
added ability to get the original url of a link from within a comment

### DIFF
--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -539,7 +539,10 @@ class CommentJsonTemplate(ThingJsonTemplate):
         if c.profilepage:
             d['link_title'] = thing.link.title
             d['link_author'] = thing.link_author.name
-            d['link_url'] = thing.link.url
+            if thing.link.is_self:
+                d['link_url'] = thing.link.make_permalink(thing.subreddit, force_domain=True)
+            else:
+                d['link_url'] = thing.link.url
         return d
 
     def rendered_data(self, wrapped):


### PR DESCRIPTION
Currently the reddit site has a link_url from a users overview page, whereas the JSON response does not. This makes it difficult to build a good experience around viewing a users profile. This pull request surfaces the link_url as a property. See http://www.reddit.com/r/redditdev/comments/1yj0x4/adding_link_url_property_for_comments/ for more information.
