### PR TITLE
Changed 'popular choices' to 'your subreddits'

### DIFF
--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -4274,7 +4274,7 @@ class SubredditSelector(Templated):
             self.subreddits = []
 
         self.subreddits.append((
-            _('popular choices'),
+            _('your subreddits'),
             Subreddit.user_subreddits(c.user, ids=False)
         ))
 


### PR DESCRIPTION
Populating a list of the subreddits you subscribe to does not make them
popular. If a user is subscribed to no subreddits, the suggestion pane
will be populated with nothing.
I think the string should be changed to your_subreddits, until at some
point there is an effort to fill the list with heavily frequented
subreddits in the event that the user has no subreddits of his/her own
to chose form