### PR TITLE
Fixing issues with /api/v1/me

### DIFF
--- a/r2/r2/controllers/reddit_base.py
+++ b/r2/r2/controllers/reddit_base.py
@@ -1088,7 +1088,7 @@ class OAuth2ResourceController(MinimalController):
 
     def check_for_bearer_token(self):
         if self._get_bearer_token(strict=False):
-            self.authenticate_with_token()
+            OAuth2ResourceController.authenticate_with_token(self)
             if c.oauth_user:
                 c.user = c.oauth_user
                 c.user_is_loggedin = True


### PR DESCRIPTION
Before refactor, `pre(self)` was called as such: `OAuth2ResourceController.pre(self)`.  Matching syntax from before.

Current clients get returned 401s when trying to access `/api/v1/me` and passing up access token w/ bearer authorization.
