### PR TITLE
Adding 'inset' in 'box-shadow'.

### DIFF
--- a/r2/r2/lib/cssfilter.py
+++ b/r2/r2/lib/cssfilter.py
@@ -106,7 +106,7 @@ custom_values = {
     
     # http://www.w3.org/TR/css3-background/#the-box-shadow
     # (This description doesn't support multiple shadows)
-    'box-shadow': 'none|(?:({box-shadow-pos}\s+)?{color}|({color}\s+?){box-shadow-pos})',
+    'box-shadow': 'none|(?:({box-shadow-pos}\s+)?{color}|({color}\s+?){box-shadow-pos})|inset',
 }
 
 def _build_regex_prefix(prefixes):


### PR DESCRIPTION
The CSS Parser right now doesn't support this feature. While working on a CSS, I came across the bug, that the CSS-parser doesn't allow shadows in all kinds of objects.
