### PR TITLE
Adding class "random-{number 1-10}" to the body tag

### DIFF
--- a/r2/r2/controllers/toolbar.py
+++ b/r2/r2/controllers/toolbar.py
@@ -185,7 +185,7 @@ class ToolbarController(RedditController):
         else:
             # It hasn't been submitted yet. Give them a chance to
             qs = utils.query_string({"url": path})
-            return self.redirect(add_sr("/submit" + qs))
+            return self.redirect(add_sr("/submit?" + qs))
 
     @validate(link = VLink('id'))
     def GET_comments(self, link):


### PR DESCRIPTION
Subreddits (/r/AskScience, for example) that want to have a random header image have to use a psuedoclass based off of the hidden input "uh", which is kinda awkward.

This'll let moderators have background colours and other parts of the page match up with the header image, and have things other than the header image be random on each page load.
