### PR TITLE
toolbar.py: Fix redirect issue when going to "reddit.com/www.some-url.com"

### DIFF
--- a/r2/r2/controllers/toolbar.py
+++ b/r2/r2/controllers/toolbar.py
@@ -185,7 +185,7 @@ class ToolbarController(RedditController):
         else:
             # It hasn't been submitted yet. Give them a chance to
             qs = utils.query_string({"url": path})
-            return self.redirect(add_sr("/submit?" + qs))
+            return self.redirect(add_sr("/submit" + qs))
 
     @validate(link = VLink('id'))
     def GET_comments(self, link):


### PR DESCRIPTION
I liked the convenience of being able to submit a URL by typing "reddit.com/" before it, but at some point it stopped working properly. It would, oddly enough, redirect to a url that looks like "/submit?%3Furl=". The solution was thankfully as simple as removing one character.

Also, sorry if the commit history looks weird on my pull requests, I am still a git when it comes to git
