### PR TITLE
Remove extra closing brace from "last edited" text.

### DIFF
--- a/r2/r2/templates/utils.html
+++ b/r2/r2/templates/utils.html
@@ -587,7 +587,7 @@ ${unsafe(txt)}
 
 <%def name="edited(thing, lastedited=None)">
   %if isinstance(thing.editted, datetime):
-    <time class="edited-timestamp" title="${_('last edited')} ${unsafe(lastedited or simplified_timesince(thing.editted))}}" datetime="${html_datetime(thing.editted)}">*</time>
+    <time class="edited-timestamp" title="${_('last edited')} ${unsafe(lastedited or simplified_timesince(thing.editted))}" datetime="${html_datetime(thing.editted)}">*</time>
   %elif thing.editted:
     <em>*</em>
   %endif


### PR DESCRIPTION
It's an unmatched closing brace.
Screenshot from /r/talesfromtechsupport: http://i.imgur.com/OlTGv7H.png

Reddit thread: http://www.reddit.com/r/bugs/comments/23zqxn/last_edited_text_contains_a_closing_brace/

Edit: Copied in the information I posted in the thread.
