### PR TITLE
Remove extra "ago" in comment's time seen through compact view.

### DIFF
--- a/r2/r2/templates/comment.compact
+++ b/r2/r2/templates/comment.compact
@@ -68,7 +68,7 @@
      %endif
      &#32;
      ## thing.timesince is a cache stub
-     ${unsafe(_("%(timeago)s ago") % dict(timeago=thing.timesince))}
+     ${unsafe(_("%(timeago)s") % dict(timeago=thing.timesince))}
      % if thing.gilded_message:
        <span class="gilded-icon" title="${thing.gilded_message}" data-count="${thing.gildings}">
          % if thing.gildings > 1:


### PR DESCRIPTION
Changed compact-view comment template, so that a second "ago" isn't put after a comment's "time ago" in compact-view. 
