### PR TITLE
It's not needed to invoke bash with the -e option.

### DIFF
--- a/install-reddit.sh
+++ b/install-reddit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # The contents of this file are subject to the Common Public Attribution
 # License Version 1.0. (the "License"); you may not use this file except in
 # compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
This patch is super simple :) Basically, the first command of the install-reddit.sh file is "set -e". Therefore, we don't have to invoke bash with "#!/bin/bash -e". We can either remove the -e from the "#!/bin/bash -e" or we can remove "set -e". I prefer removing "set -e" because it's more explicit.
