### PR TITLE
Change dropdown cursor to pointer

### DIFF
--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -298,7 +298,7 @@ ul.flat-vert {text-align: left;}
 }
 
 .dropdown {
-    cursor: default;
+    cursor: pointer;
     display: inline;
     position: relative;
 }


### PR DESCRIPTION
Change the cursor when hovering over a dropdown activator to a pointer (hand) for consistency with other clickable elements.