### PR TITLE
Add support for Markdown spoiler tags

### DIFF
--- a/r2/r2/lib/filters.py
+++ b/r2/r2/lib/filters.py
@@ -181,7 +181,7 @@ markdown_ok_tags = {
 
 markdown_boring_tags =  ('p', 'em', 'strong', 'br', 'ol', 'ul', 'hr', 'li',
                          'pre', 'code', 'blockquote', 'center',
-                          'sup', 'del', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',)
+                          'sup', 'del', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'span')
 
 markdown_user_tags = ('table', 'th', 'tr', 'td', 'tbody',
                      'tbody', 'thead', 'tr', 'tfoot', 'caption')

--- a/r2/r2/public/static/css/compact.css
+++ b/r2/r2/public/static/css/compact.css
@@ -548,6 +548,14 @@ body.toolbar { margin: 0px; padding: 0px; overflow: hidden; }
 
 .md blockquote, .help blockquote { border-left: 2px solid #369; padding-left: 4px; margin: 5px; margin-right: 15px; }
 
+.md blockquote.spoiler { border-left: 2px solid #000; color: #000; background: #000; }
+
+.md blockquote.spoiler > * { visibility: hidden; }
+
+.md blockquote.spoiler:hover { background: inherit; }
+
+.md blockquote.spoiler:hover > * { visibility: visible; }
+
 .md td, .md th { border: 1px solid #EEE; padding: 1px 3px; }
 
 .md th { font-weight: bold; }

--- a/r2/r2/public/static/css/compact.css
+++ b/r2/r2/public/static/css/compact.css
@@ -552,9 +552,13 @@ body.toolbar { margin: 0px; padding: 0px; overflow: hidden; }
 
 .md blockquote.spoiler > * { visibility: hidden; }
 
-.md blockquote.spoiler:hover { background: inherit; }
+.md blockquote.spoiler:hover, .md blockquote.spoiler:active { background: inherit; }
 
-.md blockquote.spoiler:hover > * { visibility: visible; }
+.md blockquote.spoiler:hover > *, .md blockquote.spoiler:active > * { visibility: visible; }
+
+.md span.spoiler, .md span.spoiler * { background: #000; color: #000; }
+
+.md span.spoiler:hover, .md span.spoiler:hover *, .md span.spoiler:hover, .md span.spoiler:active * { background: none; color: inherit; }
 
 .md td, .md th { border: 1px solid #EEE; padding: 1px 3px; }
 

--- a/r2/r2/public/static/css/compact.scss
+++ b/r2/r2/public/static/css/compact.scss
@@ -1499,6 +1499,20 @@ body.toolbar {
     margin: 5px;
     margin-right: 15px;
 }
+.md blockquote.spoiler {
+    border-left: 2px solid #000;
+	color: #000;
+    background: #000;
+}
+.md blockquote.spoiler > * {
+	visibility: hidden;
+}
+.md blockquote.spoiler:hover {
+    background: inherit;
+}
+.md blockquote.spoiler:hover > * {
+    visibility: visible;
+}
 .md td, .md th { border: 1px solid #EEE; padding: 1px 3px; }
 .md th { font-weight: bold;  }
 .md table { margin: 5px 10px;  }

--- a/r2/r2/public/static/css/compact.scss
+++ b/r2/r2/public/static/css/compact.scss
@@ -1501,17 +1501,24 @@ body.toolbar {
 }
 .md blockquote.spoiler {
     border-left: 2px solid #000;
-	color: #000;
     background: #000;
 }
 .md blockquote.spoiler > * {
 	visibility: hidden;
 }
-.md blockquote.spoiler:hover {
+.md blockquote.spoiler:hover, .md blockquote.spoiler:active {
     background: inherit;
 }
-.md blockquote.spoiler:hover > * {
+.md blockquote.spoiler:hover > *, .md blockquote.spoiler:active > * {
     visibility: visible;
+}
+.md span.spoiler, .md span.spoiler * {
+    background: #000;
+	color: #000;
+}
+.md span.spoiler:hover, .md span.spoiler:hover *, .md span.spoiler:hover, .md span.spoiler:active * {
+    background: none;
+	color: inherit;
 }
 .md td, .md th { border: 1px solid #EEE; padding: 1px 3px; }
 .md th { font-weight: bold;  }

--- a/r2/r2/public/static/css/mobile.css
+++ b/r2/r2/public/static/css/mobile.css
@@ -153,5 +153,7 @@ a.author, .flair, .linkflair { margin-right: 0.5em }
 .author.submitter { color: white; background-color: #5F99CF; padding: 0 4px; }
 .md blockquote.spoiler { color: #000; background: #000; }
 .md blockquote.spoiler > * { visibility: hidden; }
-.md blockquote.spoiler:hover { background: inherit; }
-.md blockquote.spoiler:hover > * { visibility: visible; }
+.md blockquote.spoiler:hover, .md blockquote.spoiler:active { background: inherit; }
+.md blockquote.spoiler:hover > *, .md blockquote.spoiler:active > * { visibility: visible; }
+.md span.spoiler, .md span.spoiler * { background: #000; color: #000; }
+.md span.spoiler:hover, .md span.spoiler:hover *, .md span.spoiler:hover, .md span.spoiler:active * { background: none; color: inherit; }

--- a/r2/r2/public/static/css/mobile.css
+++ b/r2/r2/public/static/css/mobile.css
@@ -151,3 +151,7 @@ ul {
 .linkflair { display: inline-block; font-size: small; max-width: 10em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 a.author, .flair, .linkflair { margin-right: 0.5em }
 .author.submitter { color: white; background-color: #5F99CF; padding: 0 4px; }
+.md blockquote.spoiler { color: #000; background: #000; }
+.md blockquote.spoiler > * { visibility: hidden; }
+.md blockquote.spoiler:hover { background: inherit; }
+.md blockquote.spoiler:hover > * { visibility: visible; }

--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -1800,6 +1800,19 @@ body.with-listing-chooser.explore-page #header .pagename {
     margin: 5px;
     margin-right: 15px;
 }
+.md blockquote.spoiler {
+    border-left: 2px solid #000;
+    background: #000;
+}
+.md blockquote.spoiler > * {
+	visibility: hidden;
+}
+.md blockquote.spoiler:hover {
+    background: inherit;
+}
+.md blockquote.spoiler:hover > * {
+    visibility: visible;
+}
 .md td, .md th { border: 1px solid #EEE; padding: 1px 3px; }
 .md th { font-weight: bold;  }
 .md table { margin: 5px 10px;  }

--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -1807,11 +1807,19 @@ body.with-listing-chooser.explore-page #header .pagename {
 .md blockquote.spoiler > * {
 	visibility: hidden;
 }
-.md blockquote.spoiler:hover {
+.md blockquote.spoiler:hover, .md blockquote.spoiler:active {
     background: inherit;
 }
-.md blockquote.spoiler:hover > * {
+.md blockquote.spoiler:hover > *, .md blockquote.spoiler:active > * {
     visibility: visible;
+}
+.md span.spoiler, .md span.spoiler * {
+    background: #000;
+	color: #000;
+}
+.md span.spoiler:hover, .md span.spoiler:hover *, .md span.spoiler:hover, .md span.spoiler:active * {
+    background: none;
+	color: inherit;
 }
 .md td, .md th { border: 1px solid #EEE; padding: 1px 3px; }
 .md th { font-weight: bold;  }

--- a/r2/r2/templates/usertext.compact
+++ b/r2/r2/templates/usertext.compact
@@ -154,10 +154,14 @@
             <td>super<sup>script</sup></td>
         </tr>
         <tr>
-            <td>&gt;! ${_( "spoiler")}</td>
-            <td><blockquote class="spoiler">${_( "spoiler" )}</blockquote></td>
+            <td>&gt;!${_( "spoiler text")}!&lt;</td>
+            <td><span class="spoiler">${_( "spoiler text" )}</span></td>
         </tr>
-        </table>
+        <tr>
+            <td>&gt;! ${_( "spoiler quote")}</td>
+            <td><blockquote class="spoiler">${_( "spoiler quote" )}</blockquote></td>
+        </tr>
+      </table>
       </div>
     </div>
   %endif

--- a/r2/r2/templates/usertext.compact
+++ b/r2/r2/templates/usertext.compact
@@ -153,7 +153,11 @@
             <td>super^script</td>
             <td>super<sup>script</sup></td>
         </tr>
-      </table>
+        <tr>
+            <td>&gt;! ${_( "spoiler")}</td>
+            <td><blockquote class="spoiler">${_( "spoiler" )}</blockquote></td>
+        </tr>
+        </table>
       </div>
     </div>
   %endif

--- a/r2/r2/templates/usertext.html
+++ b/r2/r2/templates/usertext.html
@@ -95,8 +95,12 @@
           <td>super<sup>script</sup></td>
       </tr>
       <tr>
-        <td>&gt;! ${_( "spoiler")}</td>
-        <td><blockquote class="spoiler">${_( "spoiler" )}</blockquote></td>
+        <td>&gt;!${_( "spoiler text")}!&lt;</td>
+        <td><span class="spoiler">${_( "spoiler text" )}</span></td>
+      </tr>
+      <tr>
+        <td>&gt;! ${_( "spoiler quote")}</td>
+        <td><blockquote class="spoiler">${_( "spoiler quote" )}</blockquote></td>
       </tr>
     </table>
   </div>

--- a/r2/r2/templates/usertext.html
+++ b/r2/r2/templates/usertext.html
@@ -94,6 +94,10 @@
           <td>super^script</td>
           <td>super<sup>script</sup></td>
       </tr>
+      <tr>
+        <td>&gt;! ${_( "spoiler")}</td>
+        <td><blockquote class="spoiler">${_( "spoiler" )}</blockquote></td>
+      </tr>
     </table>
   </div>
 </%def>


### PR DESCRIPTION
Over on Stack Exchange, they implemented spoiler tags this way:

    >! spoiler!

Which would get rendered as:

    <blockquote class="spoiler">spoiler!</blockquote>

Built-in spoiler markdown is a popular request on reddit, and I think this'll make spoilers much nicer to use on reddit (especially on mobile). This won't support inline spoilers, though; some other syntax will need to be implemented.

In a commit to `snudown`, I committed the changes to the parser.

Edit: I've also added support for inline spoilers that work like this:

    This sentence has a >!spoiler tag!< in it.