### PR TITLE
Fix rendering of subreddit traffic graphs.

### DIFF
--- a/r2/r2/public/static/js/timeseries.js
+++ b/r2/r2/public/static/js/timeseries.js
@@ -18,8 +18,6 @@ r.timeseries = {
     _formatTick: function (val, axis) {
         if (val == 0)
             return '0'
-        else if (val < 10)
-            return val.toFixed(2)
 
         for (var i = 1; i < this._units.length; i++) {
             if (val / Math.pow(1000, i - 1) < 1000) {
@@ -29,7 +27,8 @@ r.timeseries = {
 
         val /= Math.pow(1000, i - 1)
 
-        return val.toFixed(axis.tickDecimals) + this._units[i - 1]
+        var sigDigit = Math.pow(10, axis.tickDecimals)
+        return Math.round(val * sigDigit) / sigDigit + this._units[i - 1]
     },
 
     makeTimeSeriesChartsFromTable: function (table) {
@@ -145,6 +144,7 @@ r.timeseries = {
 
             yaxis: {
                 min: 0,
+                tickDecimals: 1,
                 tickFormatter: $.proxy(this, '_formatTick')
             }
         }


### PR DESCRIPTION
While looking at subreddit traffic graphs (e.g. http://www.reddit.com/r/kdrama/about/traffic), I noticed that the x-axis grid is out of alighment, when interpreting the graph against the respective data table.

In the following example: http://jsbin.com/qequcove/9 
The x-axis grid for all graphs are out of order by one unit (hour, day, month) to the right. For instance, in the graph **uniques by month**, you would need to shift the x-axis cyclically to the left by one month.

I've noticed that the data fed to jQuery Flot is in **reversed order**. Since the graph style is **stepping lines**, and due to the nature that jQuery Flot may be interpreting data linearly and constructing graphs based on that order, the x-axis grid appears to be out of alignment. 

This can be simply fixed by constructing Flot data in the right order.

See the following for the correct grid alignment: http://jsbin.com/qequcove/10

---

Also, `s.maxValue` should only be written whenever a datum is added.

---

To do:
- [x] duplicate latest data point and increase by one time unit for graph readability
- [x] resolve y-axis labels with integer values (very small data)
