### PR TITLE
Add header bar first link left padding

### DIFF
--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -4154,6 +4154,10 @@ ul#image-preview-list .description pre {
     line-height: 18px;
  }
 
+#sr-header-area a:first-child {
+    padding-left: 4px;
+}
+
 #sr-header-area .width-clip {
     position: absolute;
     left: 0;


### PR DESCRIPTION
The first link in the top bar is nudged right against the border of my monitor. On my laptop, it appears cut off a little (the plastic frame overlaps the LCD). It also just looks better.

Before:
![reddit before](https://cloud.githubusercontent.com/assets/4472083/3126338/faafb7be-e79e-11e3-9090-5fed8164973b.png)
After:
![reddit after](https://cloud.githubusercontent.com/assets/4472083/3126341/ff5f922a-e79e-11e3-9caa-e533fabf29a3.png)

I added a `padding-left` of 4px. I used the `first-child` pseudo-element selector to ensure future proofing (any link there will also have that padding).