### PR TITLE
toolbar.py: Remove '?' causing failed submission page redirects

### DIFF
--- a/r2/r2/controllers/toolbar.py
+++ b/r2/r2/controllers/toolbar.py
@@ -185,7 +185,7 @@ class ToolbarController(RedditController):
         else:
             # It hasn't been submitted yet. Give them a chance to
             qs = utils.query_string({"url": path})
-            return self.redirect(add_sr("/submit?" + qs))
+            return self.redirect(add_sr("/submit" + qs))
 
     @validate(link = VLink('id'))
     def GET_comments(self, link):


### PR DESCRIPTION
If you went to:

http://reddit.com/someurl.com

You would get sent to:

http://www.reddit.com/submit?%3Furl=http%3A%2F%2Fsomeurl.com

Which causes the URL to not be put in the URL field; removing the ? in "/submit?" fixes this.

(resubmitted because of problems with the previous PR)
