### PR TITLE
Allow timestamp() to determine tense, rather than hardcoding.

### DIFF
--- a/r2/r2/templates/usertableitem.html
+++ b/r2/r2/templates/usertableitem.html
@@ -70,7 +70,7 @@
       <span class="status"></span>
     </form>
   %elif thing.name == "age":
-      ${unsafe(_("%(when)s&#32;ago") % dict(when=timestamp(thing.rel._date)))}
+      ${unsafe(_("%(when)s") % dict(when=timestamp(thing.rel._date, include_tense=True)))}
   %elif thing.name == "permissions":
       ${thing.permissions}
   %elif thing.name == "permissionsctl":


### PR DESCRIPTION
Allow timestamp() to determine tense, rather than hardcoding.

Resolves #1053
