### PR TITLE
/widget: Use an acceptable callback for the .embed preview

### DIFF
--- a/r2/r2/templates/widgetdemopanel.html
+++ b/r2/r2/templates/widgetdemopanel.html
@@ -43,6 +43,10 @@ function getrval(r) {
     } 
 }
 
+function showPreview(val) {
+  $("#previewbox").html(val)
+}
+
 function update() {
     f = document.forms.widget;
     which = getrval(f.which);
@@ -95,7 +99,7 @@ function update() {
                       escapeHTML(url).replace(/&amp;/g, '&') + 
                       '" type="text/javascript"><'+'/script>';
     $("#codebox").html(escapeHTML(script));
-    $.getScript(url+'&callback=' + encodeURIComponent('$("#previewbox").html'));
+    $.getScript(url+'&callback=showPreview');
                       
     }
 </script>


### PR DESCRIPTION
Should partially fix the issue described in http://www.reddit.com/r/bugs/comments/2779mt/widget_pages_reloading_and_display_404_or_400/ where the callback was getting rejected and always returning `400`.
