### PR TITLE
Remove a back button-breaking hack in .compact

### DIFF
--- a/r2/r2/public/static/js/compact.js
+++ b/r2/r2/public/static/js/compact.js
@@ -41,10 +41,6 @@
 })(jQuery);
 
 $(function() {
-    if ($(window).scrollTop() == 0) {
-        $(window).scrollTop(1);
-    }
-    ;
     /* Top menu dropdown*/
     $('#topmenu_toggle').click(function() {
         $(this).toggleClass("active");


### PR DESCRIPTION
Scrolling the document down by a pixel used to hide the navigation bar in iOS Safari. It doesn't do anything in newer versions of iOS Safari, but it does make iOS Chrome lose its scroll position when you go back to a .compact page.

http://www.reddit.com/r/bugs/comments/2a5ee0/when_using_compact_on_ios_chrome_if_i_go_back_the/