### PR TITLE
Fix: URL type for geoip_location

### DIFF
--- a/r2/example.ini
+++ b/r2/example.ini
@@ -372,7 +372,7 @@ case_sensitive_domains = i.imgur.com, youtube.com
 # whether to load reddit private code (a hack until we structure it better)
 import_private = false
 # location of geoip service
-geoip_location = 127.0.0.1:5000
+geoip_location = http://127.0.0.1:5000
 
 
 ############################################ AUTHENTICATION


### PR DESCRIPTION
Fixes this error message in the default configuration:
reddit-paster: Failed to fetch GeoIP information: URLError('unknown url
type: 127.0.0.1',)

Signed-off-by: Julien Desfossez jdesfossez@efficios.com
