### PR TITLE
Remove reddit-ie6-hax.css and reddit-ie7-hax.css from the Makefile since...

### DIFF
--- a/r2/Makefile
+++ b/r2/Makefile
@@ -87,7 +87,7 @@ clean_ini:
 #################### CSS file lists
 SPRITED_STYLESHEETS += reddit.less compact.css
 LESS_STYLESHEETS := wiki.less adminbar.less policies.less
-OTHER_STYLESHEETS := reddit-ie6-hax.css reddit-ie7-hax.css mobile.css highlight.css
+OTHER_STYLESHEETS := mobile.css highlight.css
 
 #################### Static Files
 STATIC_ROOT := r2/public


### PR DESCRIPTION
The Makefile is currently breaking on a clean build because it can't find the files.

These files were removed in 21041360e0eb3021d12e24a6aa848375b324992f 
