### PR TITLE
Fix flairselection dropping under elements

### DIFF
--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -3990,10 +3990,10 @@ form input[type=radio] {margin: 2px .5em 0 0; }
        which we could try to fix here some day. */
 }
 
-div.banned-user {
+.thing.spam.banned-user {
     overflow: hidden;
-    opacity: .7;
-    filter:alpha(opacity=70); /* IE patch */
+    background-color: #fba69c;
+    color: #8D8D8D;
 }
 
 div.banned-user .title {

--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -3994,6 +3994,7 @@ form input[type=radio] {margin: 2px .5em 0 0; }
     overflow: hidden;
     background-color: #fba69c;
     color: #8D8D8D;
+    outline: dashed 2px #fba69c;
 }
 
 div.banned-user .title {


### PR DESCRIPTION
Changing the opacity of elements messes with their z-index. I got the following screenshot from a person using our mod toolbox extension:

- http://i.imgur.com/DqHffaX.png 

On investigation I found that it was not toolbox or RES related but rather the fact that shadowbanned submissions have an opacity of 0.7. Removing the opacity and setting a background resulting in the same color instead fixes this issue.