### PR TITLE
Fixing duplicates/other-discussions page for selfposts on .compact

### DIFF
--- a/r2/r2/templates/listing.compact
+++ b/r2/r2/templates/listing.compact
@@ -33,15 +33,10 @@
   %for a in thing.things:
       ${a}
   %endfor
-  
-  %if not thing.things:
-      <p id="noresults" class="error">${_("there doesn't seem to be anything here")}</p>
-  %endif
-
 </div>
 
 %if thing.nextprev and thing.next:
-<script type="text/javascript"> 
+<script type="text/javascript">
 $($(window).scroll(function(){
             var loading = $(".loading").length;
             if (!loading && $(window).scrollTop() > 
@@ -50,4 +45,8 @@ $($(window).scroll(function(){
                 } 
             }))
 </script>
+%endif
+
+%if not thing.things:
+  <p id="noresults" class="error">${_("there doesn't seem to be anything here")}</p>
 %endif


### PR DESCRIPTION
Currently when you visit a page like [this:](http://www.reddit.com/r/trendingsubreddits/duplicates/2bohnk/trending_subreddits_for_20140725_rshubreddit/.compact) it says that there is no other discussion but as you can in the [non-compact version](http://www.reddit.com/r/trendingsubreddits/duplicates/2bohnk/trending_subreddits_for_20140725_rshubreddit/) there are discussions. This only happens on self-posts.

I am not 100% sure this will fix it.
