### PR TITLE
Declare the right margin of the over18 div

### DIFF
--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -3954,6 +3954,7 @@ form input[type=radio] {margin: 2px .5em 0 0; }
 .preftable .spacer { margin-bottom: 5px; }
 .preftable .note { width: 100%; vertical-align: top; padding-top: 10px; }
 
+.over18 { margin-right: 305px; }
 .over18 button { margin: 0 10px 0 10px; padding: 5px}
 
 .entry .buttons li.nsfw-stamp {


### PR DESCRIPTION
This fixes the issue discussed in #1096. I looked at the div directly preceding the over18 one (which is the welcome message) which has a right margin of 305px as well, so hopefully this is an acceptable way to fix this bug.
