### PR TITLE
Add 'order' to CSS properties

### DIFF
--- a/r2/r2/lib/cssfilter.py
+++ b/r2/r2/lib/cssfilter.py
@@ -204,6 +204,7 @@ SAFE_PROPERTIES = {
     "min-height",
     "min-width",
     "opacity",
+    "order",
     "orphans",
     "outline",
     "outline-color",


### PR DESCRIPTION
Allow the order property for sorting flex items
