### PR TITLE
Fixed widget creation page

### DIFF
--- a/r2/r2/templates/widgetdemopanel.html
+++ b/r2/r2/templates/widgetdemopanel.html
@@ -43,6 +43,10 @@ function getrval(r) {
     } 
 }
 
+function widgetCallback(html) {
+   $("#previewbox").html(html);
+}
+
 function update() {
     f = document.forms.widget;
     which = getrval(f.which);
@@ -95,7 +99,7 @@ function update() {
                       escapeHTML(url).replace(/&amp;/g, '&') + 
                       '" type="text/javascript"><'+'/script>';
     $("#codebox").html(escapeHTML(script));
-    $.getScript(url+'&callback=' + encodeURIComponent('$("#previewbox").html'));
+    $.getScript(url+'&callback=widgetCallback');
                       
     }
 </script>


### PR DESCRIPTION
Originally, whenever a user tried to configure a widget on the configuration page, the document's body would be set to an HTTP error code. This fixes this issue.