### PR TITLE
Remove 7em padding-right on advertising links

### DIFF
--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -1465,7 +1465,6 @@ body.with-listing-chooser.explore-page #header .pagename {
 .organic-listing .link,
 .organic-listing .link.compressed,
 .organic-listing .link.promotedlink {
-    padding-right: 7em;
     padding-left: 2px;
     margin-bottom: 0px;  
 }


### PR DESCRIPTION
Causes the text in the title of the advertising to pile up on smaller resolutions, pushing content down & being harder to read.

Before:

![](http://i.imgur.com/5LOLRw0.png)


------------------

After:
![](http://i.imgur.com/uZoDyWt.png)


