### PR TITLE
Replaced SQL functions' params with named params

### DIFF
--- a/sql/functions.sql
+++ b/sql/functions.sql
@@ -20,29 +20,30 @@
 -- reddit Inc. All Rights Reserved.
 -------------------------------------------------------------------------------
 
+
 create or replace function hot(ups integer, downs integer, date timestamp with time zone) returns numeric as $$
-    select round(cast(log(greatest(abs($1 - $2), 1)) * sign($1 - $2) + (date_part('epoch', $3) - 1134028003) / 45000.0 as numeric), 7)
+    select round(cast(log(greatest(abs(ups - downs), 1)) * sign(ups - downs) + (date_part('epoch', date) - 1134028003) / 45000.0 as numeric), 7)
 $$ language sql immutable;
 
 create or replace function score(ups integer, downs integer) returns integer as $$
-    select $1 - $2
+    select ups - downs
 $$ language sql immutable;
 
 create or replace function controversy(ups integer, downs integer) returns float as $$
-    select CASE WHEN $1 <= 0 or $2 <= 0 THEN 0
-                WHEN $1 > $2 THEN power($1 + $2, cast($2 as float) / $1)
-                ELSE power($1 + $2, cast($1 as float) / $2)
+    select CASE WHEN ups <= 0 or downs <= 0 THEN 0
+                WHEN ups > downs THEN power(ups + downs, cast(downs as float) / ups)
+                ELSE power(ups + downs, cast(ups as float) / downs)
            END;
 $$ language sql immutable;
 
 create or replace function ip_network(ip text) returns text as $$
-    select substring($1 from E'[\\d]+\.[\\d]+\.[\\d]+')
+    select substring(ip from E'[\\d]+\.[\\d]+\.[\\d]+')
 $$ language sql immutable;
 
 create or replace function base_url(url text) returns text as $$
-    select substring($1 from E'(?i)(?:.+?://)?(?:www[\\d]*\\.)?([^#]*[^#/])/?')
+    select substring(url from E'(?i)(?:.+?://)?(?:www[\\d]*\\.)?([^#]*[^#/])/?')
 $$ language sql immutable;
 
 create or replace function domain(url text) returns text as $$
-    select substring($1 from E'(?i)(?:.+?://)?(?:www[\\d]*\\.)?([^#/]*)/?')
+    select substring(url from E'(?i)(?:.+?://)?(?:www[\\d]*\\.)?([^#/]*)/?')
 $$ language sql immutable;


### PR DESCRIPTION
Changed SQL functions to use named parameters instead of positional parameters, which improves readability. Named params are implemented in all currently supported versions of Postgresql.