### PR TITLE
Do not request gzipped media responses by default.

### DIFF
--- a/r2/r2/lib/media.py
+++ b/r2/r2/lib/media.py
@@ -126,14 +126,15 @@ def _clean_url(url):
     return url
 
 
-def _initialize_request(url, referer):
+def _initialize_request(url, referer, gzip=False):
     url = _clean_url(url)
 
     if not url.startswith(("http://", "https://")):
         return
 
     req = urllib2.Request(url)
-    req.add_header('Accept-Encoding', 'gzip')
+    if gzip:
+        req.add_header('Accept-Encoding', 'gzip')
     if g.useragent:
         req.add_header('User-Agent', g.useragent)
     if referer:
@@ -142,7 +143,7 @@ def _initialize_request(url, referer):
 
 
 def _fetch_url(url, referer=None):
-    request = _initialize_request(url, referer=referer)
+    request = _initialize_request(url, referer=referer, gzip=True)
     if not request:
         return None, None
     response = urllib2.urlopen(request)


### PR DESCRIPTION
For some reason, Twitter's image server will sometimes gzip the main profile picture found on a tweet page. Since we don't properly deflate this gzipped image in _fetch_image_size(), we end up tossing out the main account's profile image as a possible thumbnail. Since this behaviour only happens sometimes, our scraper eventually finds a non-gzipped image it can use, meaning we sometimes snag some random person's profile image erroneously.

Example: http://redd.it/2gh3mu

Images generally don't benefit from gzip compression. We also chunk image fetching so it is unlikely we'll grab much more than 1k. Instead of trying to deflate these oddly gzipped images, I've made _initialize_request() not fetch gzipped objects by default, and have modified _fetch_url() to request gzipped objects since it _does_ properly deflate.

:eyeglasses: @umbrae @deimos
