### PR TITLE
Add a JSON template for UploadedImages

### DIFF
--- a/r2/r2/config/templates.py
+++ b/r2/r2/config/templates.py
@@ -75,6 +75,7 @@ api('flairselector', FlairSelectorJsonTemplate)
 api('subredditstylesheet', StylesheetTemplate)
 api('subredditstylesheetsource', StylesheetTemplate)
 api('createsubreddit', SubredditSettingsTemplate)
+api('uploadedimage', UploadedImageJsonTemplate)
 
 api('modaction', ModActionTemplate)
 

--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -1034,6 +1034,15 @@ class SubredditSettingsTemplate(ThingJsonTemplate):
             return getattr(thing.site, attr[5:])
         return ThingJsonTemplate.thing_attr(self, thing, attr)
 
+
+class UploadedImageJsonTemplate(JsonTemplate):
+    def render(self, thing, *a, **kw):
+        return ObjectTemplate({
+            "errors": list(k for (k, v) in thing.errors if v),
+            "img_src": thing.img_src,
+        })
+
+
 class ModActionTemplate(ThingJsonTemplate):
     _data_attrs_ = dict(
         action='action',

--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -2370,6 +2370,9 @@ class UploadedImage(Templated):
         Templated.__init__(self, status=status, img_src=img_src, name = name,
                            form_id = form_id)
 
+    def render(self, *a, **kw):
+        return responsive(Templated.render(self, *a, **kw))
+
 class Thanks(Templated):
     """The page to claim reddit gold trophies"""
     def __init__(self, secret=None):


### PR DESCRIPTION
:eyeglasses: @Deimos 

This should make the upload status / resultant URL visible to API consumers. If you're feeling lazy (like I was) you can just add .json to the `<form>`'s action and watch the request in Chrome's web inspector to test.
