### PR TITLE
Correct viewport meta tag syntax

### DIFF
--- a/r2/r2/templates/base.compact
+++ b/r2/r2/templates/base.compact
@@ -37,7 +37,7 @@
       <link rel="shorturl" href="http://${thing.shortlink}" />
     %endif
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
-    <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
     <title>${self.Title()}</title>
     <meta name="title" content="${self.Title()}" />
     <meta name="description" content="${thing.short_description or g.short_description}" />

--- a/r2/r2/templates/reddit.mobile
+++ b/r2/r2/templates/reddit.mobile
@@ -55,7 +55,7 @@ ${thing.content and thing.content() or ''}
   <link rel="apple-touch-icon" href="/static/compact/reddit-apple-mobile-device.png">
   <link rel="apple-touch-startup-image" href="/static/compact/reddit_startimg.png">
 
-  <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 
 </%def>
 


### PR DESCRIPTION
Fixes #1073. Brings meta tags into more complete compliance with [the 2013 CSS Device Adaptation draft](https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag). In this case:
- delimiters are changed to commas, which is not required but preferred
- negative indication is "no," not "0"
- there is no trailing delimiter

This commit does not alter the UX or mobile display at all - it is purely a standards-compliance-motivated change.
