### PR TITLE
Sticky URL should respect sort parameter

### DIFF
--- a/r2/r2/controllers/front.py
+++ b/r2/r2/controllers/front.py
@@ -808,7 +808,8 @@ class FrontController(RedditController):
     def GET_sticky(self):
         if c.site.sticky_fullname:
             sticky = Link._by_fullname(c.site.sticky_fullname, data=True)
-            self.redirect(sticky.make_permalink_slow())
+            qs = query_string(request.GET)
+            self.redirect(sticky.make_permalink_slow() + qs)
         else:
             abort(404)
 


### PR DESCRIPTION
http://www.reddit.com/r/ideasfortheadmins/comments/209xxg/sticky_url_should_respect_sort_parameter/

For example this: http://www.reddit.com/r/melbourne/about/sticky leads to the current sticky, which could give people a permalink to put in their bookmarks for the day's random discussion.

Currently this is the link: http://www.reddit.com/r/melbourne/comments/208jub/its_the_rmelbourne_random_discussion_thread/

However, the former does not respect the ?sort=new flag, which is convenient especially when the thread has grown and people would like to see new replies without needing either to manually edit (although while this bit does not apply any longer, it's still a drag to tell people to click the select box etc., etc., when it should just be permalink-able, similar to the thread's actual URL) the URL or messing up their global comment sorting.

A similar construct is currently in use here: https://github.com/reddit/reddit/blob/670550d26c250a335ac4a3baefb798d966647591/r2/r2/controllers/front.py#L1614

To redirect for failed Reddit Gold checkouts.
