### PR TITLE
fix mobile compact view not respecting user preference of opening links in new windows

### DIFF
--- a/r2/r2/templates/link.compact
+++ b/r2/r2/templates/link.compact
@@ -78,7 +78,7 @@
   %endif
     ${thumbnail()}
     <p class="title">
-    <a href="${url}">${thing.title}</a>
+    <a href="${url}" class="may-blank">${thing.title}</a>
     %if c.site.link_flair_position == 'right' and thing.flair_text:
       ${flair()}
     %endif


### PR DESCRIPTION
For some reason the main link in compact view on i.reddit.com does not have this CSS class so links aren't opening in new windows (from the callback in ui.js).

Most of the other links on the compact view page have this class and open in new windows properly, and the main link on non-compact view has it, so this adds it in the compact view.
