### PR TITLE
Include user's index preference in account API

### DIFF
--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -31,9 +31,8 @@ from r2.models import Account, Report
 from r2.models.subreddit import SubSR
 from r2.models.token import OAuth2Scope, extra_oauth2_scope
 import time, pytz
-from pylons import c, g
+from pylons import c, g, response
 from pylons.i18n import _
-from pylons import response
 
 from r2.models.wiki import ImagesByWikiPage
 
@@ -348,7 +347,7 @@ class IdentityJsonTemplate(ThingJsonTemplate):
         if c.user_is_loggedin and thing._id == c.user._id:
             attrs.update(self._private_data_attrs)
         if thing.pref_hide_from_robots:
-            response.headers['X-Robots-Tag'] = 'noindex'
+            response.headers['X-Robots-Tag'] = 'noindex, nofollow'
         data = {k: self.thing_attr(thing, v) for k, v in attrs.iteritems()}
         try:
             self.add_message_data(data, thing)

--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -334,6 +334,7 @@ class IdentityJsonTemplate(ThingJsonTemplate):
         is_mod="is_mod",
         link_karma="link_karma",
         name="name",
+        hide_from_robots="pref_hide_from_robots",
     )
     _private_data_attrs = dict(
         over_18="pref_over_18",

--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -33,6 +33,7 @@ from r2.models.token import OAuth2Scope, extra_oauth2_scope
 import time, pytz
 from pylons import c, g
 from pylons.i18n import _
+from pylons import response
 
 from r2.models.wiki import ImagesByWikiPage
 
@@ -346,6 +347,8 @@ class IdentityJsonTemplate(ThingJsonTemplate):
         attrs = self._data_attrs_.copy()
         if c.user_is_loggedin and thing._id == c.user._id:
             attrs.update(self._private_data_attrs)
+        if thing.pref_hide_from_robots:
+            response.headers['X-Robots-Tag'] = 'noindex'
         data = {k: self.thing_attr(thing, v) for k, v in attrs.iteritems()}
         try:
             self.add_message_data(data, thing)


### PR DESCRIPTION
3rd party sites allow indexing of user profiles. Perhaps they will implement `noindex` if the user's preference is easily accessible. This is an implementation of this [request.](https://www.reddit.com/r/ideasfortheadmins/comments/2ktryi/allow_reddit_clients_to_respect_users_noindex/). I've added `hide_from_robots` value to the response as well as `x-robots-tag: noindex` to the header if noindex is enabled.
## Example response before the change:

```
GET http://reddit.local/user/test123/about.json

HTTP/1.0 200 OK
Server: PasteWSGIServer/0.5 Python/2.7.3
Date: Sat, 01 Nov 2014 02:39:04 GMT
content-type: application/json; charset=UTF-8
x-ua-compatible: IE=edge
content-length: 257
x-frame-options: SAMEORIGIN
x-content-type-options: nosniff
x-xss-protection: 1; mode=block
x-reddit-pagecache: miss
x-ratelimit-remaining: 297
x-ratelimit-used: 3
x-ratelimit-reset: 56

{
  "kind": "t2",
  "data": {
    "name": "test123",
    "is_friend": false,
    "created": 1414750716,
    "created_utc": 1414721916,
    "link_karma": 1,
    "comment_karma": 0,
    "is_gold": false,
    "is_mod": false,
    "has_verified_email": false,
    "id": "pc"
  }
}
```
## Example Response after the change:

```
GET http://reddit.local/user/test123/about.json

HTTP/1.0 200 OK
Server: PasteWSGIServer/0.5 Python/2.7.3
Date: Sat, 01 Nov 2014 02:41:17 GMT
content-type: application/json; charset=UTF-8
x-ua-compatible: IE=edge
x-robots-tag: noindex, nofollow
content-length: 256
x-frame-options: SAMEORIGIN
x-content-type-options: nosniff
x-xss-protection: 1; mode=block
x-reddit-pagecache: miss
x-ratelimit-remaining: 298
x-ratelimit-used: 2
x-ratelimit-reset: 523

{
  "kind": "t2",
  "data": {
    "name": "test123",
    "is_friend": false,
    "created": 1414750716,
    "hide_from_robots": true,
    "created_utc": 1414721916,
    "link_karma": 1,
    "comment_karma": 0,
    "is_gold": false,
    "is_mod": false,
    "has_verified_email": false,
    "id": "pc"
  }
}
```
