### PR TITLE
Corrected Link

### DIFF
--- a/r2/r2/public/static/inbound-email-policy.html
+++ b/r2/r2/public/static/inbound-email-policy.html
@@ -17,8 +17,7 @@ Unsolicited Electronic Mail Advertising is prohibited.
 <p>Text of section 17538.45 of the Business and Professional Code of the 
 State of California, copied on July 17th, 2008.  Check
 with the <a href="https://leginfo.legislature.ca.gov/faces/codes_displaySection.xhtml?lawCode=BPC&amp;sectionNum=17538.45">California 
-Law website for the current text</a> (search for section 17538 or "unsolicited" 
-in the Business and Professions Code). 
+Legislative Information website for the current text</a>. 
 </p> 
 </div>
 <pre>


### PR DESCRIPTION
HTML attributes are generally lower-case.

The link went to an outdated website. New link goes directly to the relevant legal code.
