### PR TITLE
i18n routing respects protocol

### DIFF
--- a/r2/r2/config/routing.py
+++ b/r2/r2/config/routing.py
@@ -117,7 +117,7 @@ def make_map():
     mc('/awards/received', controller='front', action='received_award')
 
     mc('/i18n', controller='redirect', action='redirect',
-       dest='http://www.reddit.com/r/i18n')
+       dest='/r/i18n')
     mc('/feedback', controller='redirect', action='redirect',
        dest='/contact')
     mc('/contact', controller='front', action='contact_us')


### PR DESCRIPTION
Previously, if a non-logged in user visited `https://www.reddit.com/i18n` they would be redirected to the _insecure_ `http://www.reddit.com/r/i18n`

Site redirection should respect security settings.
