### PR TITLE
Add votable to link api response

### DIFF
--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -460,6 +460,7 @@ class LinkJsonTemplate(ThingJsonTemplate):
         title="title",
         ups="upvotes",
         url="url",
+        votable="votable",
     )
 
     def thing_attr(self, thing, attr):


### PR DESCRIPTION
Useful for apps to determine if item can be commented/voted on

Only thing I'm not too sure on is the name, as something like `archived` might be better