### PR TITLE
Feature/markdown preview

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -1675,15 +1675,8 @@ class ApiController(RedditController):
         text=VMarkdown('text'),
     )
     @api_doc(api_section.links_and_comments)
-    def POST_preview_comment(self, commentform, jquery, text):
-        """Submit a new comment for preview.
-
-        `parent` is the fullname of the thing being replied to. Its value
-        changes the kind of object created by this request:
-
-        * the fullname of a Link: a top-level comment in that Link's thread.
-        * the fullname of a Comment: a comment reply to that comment.
-        * the fullname of a Message: a message reply to that message.
+    def GET_markdown_preview(self, commentform, jquery, text):
+        """Get formatted markdown for preview.
 
         `text` should be the raw markdown body of the comment or message.
         """

--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -1672,11 +1672,10 @@ class ApiController(RedditController):
         VUser(),
         VModhash(),
         VRatelimit(rate_user=True, rate_ip=True, prefix="rate_comment_"),
-        parent=VSubmitParent(['thing_id', 'parent']),
-        comment=VMarkdown('text'),
+        text=VMarkdown('text'),
     )
     @api_doc(api_section.links_and_comments)
-    def POST_preview_comment(self, commentform, jquery, parent, comment):
+    def POST_preview_comment(self, commentform, jquery, text):
         """Submit a new comment for preview.
 
         `parent` is the fullname of the thing being replied to. Its value
@@ -1688,7 +1687,7 @@ class ApiController(RedditController):
 
         `text` should be the raw markdown body of the comment or message.
         """
-        return safemarkdown(comment)
+        return safemarkdown(text)
 
     @require_oauth2_scope("submit")
     @validatedForm(

--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -1673,6 +1673,29 @@ class ApiController(RedditController):
         VModhash(),
         VRatelimit(rate_user=True, rate_ip=True, prefix="rate_comment_"),
         parent=VSubmitParent(['thing_id', 'parent']),
+        comment=VMarkdown('text'),
+    )
+    @api_doc(api_section.links_and_comments)
+    def POST_preview_comment(self, commentform, jquery, parent, comment):
+        """Submit a new comment for preview.
+
+        `parent` is the fullname of the thing being replied to. Its value
+        changes the kind of object created by this request:
+
+        * the fullname of a Link: a top-level comment in that Link's thread.
+        * the fullname of a Comment: a comment reply to that comment.
+        * the fullname of a Message: a message reply to that message.
+
+        `text` should be the raw markdown body of the comment or message.
+        """
+        return safemarkdown(comment)
+
+    @require_oauth2_scope("submit")
+    @validatedForm(
+        VUser(),
+        VModhash(),
+        VRatelimit(rate_user=True, rate_ip=True, prefix="rate_comment_"),
+        parent=VSubmitParent(['thing_id', 'parent']),
         comment=VMarkdownLength(['text', 'comment'], max_length=10000),
     )
     @api_doc(api_section.links_and_comments)

--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -4114,6 +4114,7 @@ class UserText(CachedTemplate):
                  expunged=False,
                  include_errors=True,
                  show_embed_help=False,
+                 show_embed_preview=False,
                 ):
 
         css_class = "usertext"
@@ -4148,6 +4149,7 @@ class UserText(CachedTemplate):
                                 expunged=expunged,
                                 include_errors=include_errors,
                                 show_embed_help=show_embed_help,
+                                show_embed_preview=show_embed_preview,
                                )
 
 class MediaEmbedBody(CachedTemplate):

--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -4786,7 +4786,7 @@ ul.tabmenu.formtab {
     margin: 5px 5px 10px 0;
 }
 
-.usertext .help-toggle, .usertext a.reddiquette {
+.usertext .help-toggle, .usertext a.reddiquette, .usertext .preview-toggle {
     font-size: smaller;
     float:right;
     margin-top: 5px; 
@@ -4799,7 +4799,7 @@ ul.tabmenu.formtab {
     width: 100%;
 }
 
-.usertext .markhelp {
+.usertext .markhelp, .usertext .markpreview {
     padding: 4px;
     margin: 5px 0px;
     border-top: 1px dotted #c0c0c0;
@@ -4813,6 +4813,11 @@ ul.tabmenu.formtab {
         width: 50%;
         border: 1px solid #c0c0c0;
     }
+}
+
+.usertext .markpreview {
+  padding: 10px 5px;
+  background-color: #EEEEEE;
 }
 
 .usertext .markhelp .spaces {background-color: #c0c0c0}

--- a/r2/r2/public/static/js/jquery.reddit.js
+++ b/r2/r2/public/static/js/jquery.reddit.js
@@ -184,7 +184,6 @@ $.request = function(op, parameters, worker_in, block, type,
 
     parameters = $.with_default(parameters, {});
     worker_in  = $.with_default(worker_in, handleResponse(action));
-
     type  = $.with_default(type, "json");
     if (typeof(worker_in) != 'function')
         worker_in  = handleResponse(action);

--- a/r2/r2/public/static/js/jquery.reddit.js
+++ b/r2/r2/public/static/js/jquery.reddit.js
@@ -184,6 +184,7 @@ $.request = function(op, parameters, worker_in, block, type,
 
     parameters = $.with_default(parameters, {});
     worker_in  = $.with_default(worker_in, handleResponse(action));
+
     type  = $.with_default(type, "json");
     if (typeof(worker_in) != 'function')
         worker_in  = handleResponse(action);

--- a/r2/r2/public/static/js/reddit.js
+++ b/r2/r2/public/static/js/reddit.js
@@ -413,8 +413,8 @@ function previewon(elem) {
       }
     };
 
-    $.request("preview_comment", get_form_fields(form, {}), success, undefined,
-              "text", false, form_error(form));
+    $.request("markdown_preview", get_form_fields(form, {}), success, undefined,
+              "text", true, form_error(form));
 };
 
 function previewoff(elem) {

--- a/r2/r2/public/static/js/reddit.js
+++ b/r2/r2/public/static/js/reddit.js
@@ -402,6 +402,25 @@ function helpoff(elem) {
     $(elem).parents(".usertext-edit:first").children(".markhelp:first").hide();
 };
 
+function previewon(elem) {
+    var form = $(elem).parents("form")[0];
+    var preview = $(elem).parents(".usertext-edit:first").children(".markpreview:first");
+    var success = function(r) {
+      if (get_form_fields(form, {}).text.length) {
+        preview.html(r).show();
+      } else {
+        preview.html("").show();
+      }
+    };
+
+    $.request("preview_comment", get_form_fields(form, {}), success, undefined,
+              "text", false, form_error(form));
+};
+
+function previewoff(elem) {
+    $(elem).parents(".usertext-edit:first").children(".markpreview:first").html("<p>Loading...</p>").hide();
+};
+
 function show_all_messages(elem) {
     var $rootMessage = $(elem).parents(".message");
     var $childMessages = $rootMessage.find(".message");

--- a/r2/r2/public/static/js/reddit.js
+++ b/r2/r2/public/static/js/reddit.js
@@ -418,7 +418,7 @@ function previewon(elem) {
 };
 
 function previewoff(elem) {
-    $(elem).parents(".usertext-edit:first").children(".markpreview:first").html("<p>Loading...</p>").hide();
+    $(elem).parents(".usertext-edit:first").children(".markpreview:first").html("").hide();
 };
 
 function show_all_messages(elem) {

--- a/r2/r2/templates/usertext.html
+++ b/r2/r2/templates/usertext.html
@@ -29,6 +29,12 @@
 <%namespace file="printablebuttons.html" import="toggle_button" />
 <%namespace file="utils.html" import="error_field, md, _md"/>
 
+<%def name="markpreview(show_embed_preview=False)">
+  <div class="markpreview" style="display:none">
+    <p>Loading...</p>
+  </div>
+</%def>
+
 <%def name="markhelp(show_embed_help=False)">
   <div class="markhelp" style="display:none">
     <p>${md(strings.formatting_help_info)}</p>
@@ -149,10 +155,13 @@
       </div>
 
       <div class="bottom-area">
+        ${toggle_button("preview-toggle", _("preview"), _("hide preview"),
+                        "previewon", "previewoff",
+                         style = "" if thing.creating else "display: none")}
+
         ${toggle_button("help-toggle", _("formatting help"), _("hide help"),
                         "helpon", "helpoff",
                          style = "" if thing.creating else "display: none")}
-
         <a href="/wiki/reddiquette" class="reddiquette" target="_blank" tabindex="100">${_('reddiquette')}</a>
 
         %if thing.include_errors:
@@ -174,6 +183,7 @@
         </div>
       </div>
 
+      ${markpreview(show_embed_preview=thing.show_embed_preview)}
       ${markhelp(show_embed_help=thing.show_embed_help)}
     </div>
   %endif

--- a/r2/r2/templates/usertext.html
+++ b/r2/r2/templates/usertext.html
@@ -31,7 +31,6 @@
 
 <%def name="markpreview(show_embed_preview=False)">
   <div class="markpreview" style="display:none">
-    <p>Loading...</p>
   </div>
 </%def>
 


### PR DESCRIPTION
fixes #133
closed #1195 in favor of a back-end approach.

More detailed description and screenshots here: http://www.reddit.com/r/ideasfortheadmins/comments/2oaw31/markdown_preview_for_comments_and_self_posts/

Using a tab-base UI approach similar to the github preview would probably be preferable. 

(this PR is a re-issue of #1201 