### PR TITLE
Change SubredditSelector to use better wording

### DIFF
--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -4737,7 +4737,7 @@ class SubredditSelector(Templated):
 
         if include_user_subscriptions:
             self.subreddits.append((
-                _('popular choices'),
+                _('Your subscribed subreddits'),
                 Subreddit.user_subreddits(c.user, ids=False)
             ))
 

--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -4737,7 +4737,7 @@ class SubredditSelector(Templated):
 
         if include_user_subscriptions:
             self.subreddits.append((
-                _('Your subscribed subreddits'),
+                _('your subscribed subreddits'),
                 Subreddit.user_subreddits(c.user, ids=False)
             ))
 


### PR DESCRIPTION
Currently, the subreddit selector when submitting a new link "/r/subreddit/submit" says "Popular Choices" and then lists the subreddits you are subscribed to.

I find this to be a big misnomer, as they are not popular choices at all, they are just a list of your subscribed subreddits. "Popular choices" implies that these are things other people have selected as well.

I know, it's super nitpicky, but I thought it might make more sense this way.