### PR TITLE
Fixed comments not loading on compact user overview page

### DIFF
--- a/r2/r2/public/static/js/compact.js
+++ b/r2/r2/public/static/js/compact.js
@@ -180,6 +180,11 @@ function fetch_more() {
         "&count=" + parseInt(last.find(".rank").html())
 
     $.getJSON(apath, function(res) {
+        if (apath.indexOf('/user/') > 0) {
+            for (i = 0; i < res.data.length; i++) {
+                res.data[i].data.parent = undefined;
+            }
+        }
         $.insert_things(res.data, true);
         $(".thing").click(function() {
         });

--- a/r2/r2/templates/comment.compact
+++ b/r2/r2/templates/comment.compact
@@ -107,5 +107,8 @@
   %else:
     <div class="child">
   %endif
-  ${thing.childlisting}</div>
+  %if thing.childlisting:
+  ${thing.childlisting}
+  %endif
+  </div>
 </div>


### PR DESCRIPTION
Removes parent attribute from the returned JSON. This fixes the issue of comments not being fetched when scrolling down on the compact user page.

Please see [issue #1206](https://github.com/reddit/reddit/issues/1206) for more information.