### PR TITLE
don't mark links visited on right click or on drag

### DIFF
--- a/r2/r2/public/static/js/visited.js
+++ b/r2/r2/public/static/js/visited.js
@@ -15,8 +15,8 @@ r.visited = {
     },
 
     onVisit: function(ev) {
-        if (ev.type == 'keydown' && ev.which != 13) {
-            // only handle enter key presses
+        if ((ev.type == 'keydown' && ev.which != 13) || (ev.which === 3)) {
+            // only handle enter key presses and/or non-right clicks
             return
         }
         this.storeVisit($(ev.target).closest('.thing').data('fullname'))

--- a/r2/r2/public/static/js/visited.js
+++ b/r2/r2/public/static/js/visited.js
@@ -15,7 +15,7 @@ r.visited = {
     },
 
     onVisit: function(ev) {
-        if ((ev.type == 'keydown' && ev.which != 13) || (ev.which === 3)) {
+        if ((ev.type == 'keydown' && ev.which != 13) || ev.which === 3) {
             // only handle enter key presses and/or non-right clicks
             return
         }

--- a/r2/r2/public/static/js/visited.js
+++ b/r2/r2/public/static/js/visited.js
@@ -4,7 +4,7 @@ r.visited = {
     init: function() {
         this.sendVisits = _.throttle(this._sendVisits, 100)
         if (r.config.logged && r.config.store_visits) {
-            $('.content').on('mousedown keydown', '.link:not(.visited) a.title, .link:not(.visited) a.thumbnail', _.bind(this.onVisit, this))
+            $('.content').on('click keydown', '.link:not(.visited) a.title, .link:not(.visited) a.thumbnail', _.bind(this.onVisit, this))
 
             // listen for custom "visit" event for third-party extensions to trigger in a non-UI specific way
             $('.content').on('visit', '.link:not(.visited)', _.bind(this.onVisit, this))


### PR DESCRIPTION
a common use case, for example, is right click / open in incognito. it's not good to add links to history when that's the user's intent, so this function shouldn't be run on right clicks.

confession: this is a blind-ish PR I whipped up real fast without testing because my VM is dead. If someone with a running VM could test this, I'd appreciate it. Otherwise, I'll try to get it running again soon.

I do think it should work though. Pretty simple change.