### PR TITLE
Add scheme to URL input if not present on losing focus

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -469,6 +469,7 @@ class ApiController(RedditController):
 
         if kind == 'link':
             if not url or form.has_errors("url", errors.NO_URL, errors.BAD_URL):
+                form.set_error(errors.BAD_URL, 'url')
                 return
 
             if form.has_errors("url", errors.DOMAIN_BANNED):

--- a/r2/r2/public/static/js/reddit.js
+++ b/r2/r2/public/static/js/reddit.js
@@ -1229,6 +1229,17 @@ $(function() {
             $("#moresearchinfo").slideUp();
             event.preventDefault();
         });
+
+        /* Add a scheme to URL input fields if not already present */
+        $("input[type=url]").blur(function() {
+            var input = $(this).val();
+            if (input && input.length > 0) {
+                var schemePresent = input.match(/^[a-z]+:\/\/.*/i);
+                if (!schemePresent) {
+                    $(this).val("http://" + input);
+                }
+            }
+        });
         
         /* Select shortlink text on click */
         $("#shortlink-text").click(function() {

--- a/r2/r2/public/static/js/reddit.js
+++ b/r2/r2/public/static/js/reddit.js
@@ -1229,17 +1229,6 @@ $(function() {
             $("#moresearchinfo").slideUp();
             event.preventDefault();
         });
-
-        /* Add a scheme to URL input fields if not already present */
-        $("input[type=url]").blur(function() {
-            var input = $(this).val();
-            if (input && input.length > 0) {
-                var schemePresent = input.match(/^[a-z]+:\/\/.*/i);
-                if (!schemePresent) {
-                    $(this).val("http://" + input);
-                }
-            }
-        });
         
         /* Select shortlink text on click */
         $("#shortlink-text").click(function() {

--- a/r2/r2/templates/newlink.compact
+++ b/r2/r2/templates/newlink.compact
@@ -67,7 +67,7 @@ ${thing.formtabs_menu}
 <div class="spacer">
   <%utils:round_field title="${_('url')}" id="url-field">
     <input name="kind" value="link" type="hidden"/>
-    <input id="url" name="url" type="url" value="${thing.url}"/>
+    <input id="url" name="url" type="text" value="${thing.url}"/>
     ${error_field("NO_URL", "url", "div")}
     ${error_field("BAD_URL", "url", "div")}
     ${error_field("ALREADY_SUB", "url", "div")}

--- a/r2/r2/templates/newlink.html
+++ b/r2/r2/templates/newlink.html
@@ -71,7 +71,7 @@ ${thing.formtabs_menu}
 <div class="spacer">
   <%utils:round_field title="${_('url')}" id="url-field">
     <input name="kind" value="link" type="hidden"/>
-    <input id="url" name="url" type="url" value="${thing.url}" required>
+    <input id="url" name="url" type="text" value="${thing.url}" required>
     ${error_field("NO_URL", "url", "div")}
     ${error_field("BAD_URL", "url", "div")}
     ${error_field("DOMAIN_BANNED", "url", "div")}


### PR DESCRIPTION
This is a fix for #1214 - which is caused by browsers that validate URL input fields preventing submission if no scheme is present, e.g. `example.com` instead of `http://example.com`. When an input field loses focus this will check if a scheme is present and prepend the input with `http://` if not.