### PR TITLE
Add documentation for /api/flair_csv

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -3328,12 +3328,12 @@ class ApiController(RedditController):
         jquery('.tagline .id-%s' % user._fullname).parent().html(unflair)
 
     @require_oauth2_scope("modflair")
-    @validate(VSrModerator(perms='flair'),
-              VModhash(),
-              flair_csv = nop(
-                          "flair_csv",
-                          docs={"flair_csv":
-                          "Comma-seperated flair information"}),
+    @validatedForm(VSrModerator(perms='flair'),
+                   VModhash(),
+                   flair_csv = nop(
+                               "flair_csv",
+                               docs={"flair_csv":
+                               "Comma-seperated flair information"}))
     @api_doc(api_section.flair, uses_site=True)
     def POST_flaircsv(self, flair_csv):
         """Change the flair of multiple users in the same subreddit with a

--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -3330,9 +3330,26 @@ class ApiController(RedditController):
     @require_oauth2_scope("modflair")
     @validate(VSrModerator(perms='flair'),
               VModhash(),
-              flair_csv = nop('flair_csv'))
+              flair_csv = nop(
+                          "flair_csv",
+                          docs={"flair_csv":
+                          "Comma-seperated flair information"}),
     @api_doc(api_section.flair, uses_site=True)
     def POST_flaircsv(self, flair_csv):
+        """Change the flair of multiple users in the same subreddit with a
+        single API call.
+
+        Requires a string 'flair_csv' which has up to 100 lines of the form
+        '`user`,`flairtext`,`cssclass`' (Lines beyond the 100th are ignored).
+
+        If both `cssclass` and `flairtext` are the empty string for a given
+        `user`, instead clears that user's flair.
+
+        Returns an array of objects indicating if each flair setting was 
+        applied, or a reason for the failure.
+
+        """
+        
         limit = 100  # max of 100 flair settings per call
         results = FlairCsv()
         # encode to UTF-8, since csv module doesn't fully support unicode


### PR DESCRIPTION
After hitting the servers with far too many flair updates last night after changing r/leagueoflegends' CSS class names, flair_csv was looking pretty attractive. Would have been nice to know what input it needed without having to read the code though, so threw some documentation in there.

This pull request should have no functional changes, only changes to what's displayed on /dev/api