### PR TITLE
Change "liked" "disliked" to "upvoted" "downvoted" in prefs page

### DIFF
--- a/r2/r2/templates/prefoptions.html
+++ b/r2/r2/templates/prefoptions.html
@@ -162,11 +162,11 @@
           ${_("(such as the source subreddit or the content author's url/name)")}
         </span>
       </p>
-      <p>${checkbox(_("don't show links after I've liked them"), "hide_ups")}
+      <p>${checkbox(_("don't show links after I've upvoted them"), "hide_ups")}
          &#32;
          <span class="little gray">${_("(except my own)")}</span>
       </p>
-      <p>${checkbox(_("don't show links after I've disliked them"), "hide_downs")}
+      <p>${checkbox(_("don't show links after I've downvoted them"), "hide_downs")}
          &#32;
          <span class="little gray">${_("(except my own)")}</span>
       </p>


### PR DESCRIPTION
Reddit itself states that upvotes/downvotes should not be used as "I like/dislike this" buttons in the reddiquette, and changing this might be a good idea to both clear the meaning of the options, and more adhere to reddit's own guidelines.

Sorry for the anon aws user commit.