### PR TITLE
Add "archived" CSS class to post if not votable

### DIFF
--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -1617,6 +1617,9 @@ class LinkInfoPage(Reddit):
                     step_str = "%dh" % (step.total_seconds() / (60 * 60))
                 classes.add("post-under-%s-old" % step_str)
 
+        if not getattr(self.link, "votable", True):
+            classes.add("archived")
+
         return classes
 
 class LinkCommentSep(Templated):

--- a/r2/r2/templates/link.html
+++ b/r2/r2/templates/link.html
@@ -156,7 +156,7 @@
 </%def>
 
 <%def name="thing_css_class(what)" buffered="True">
-${parent.thing_css_class(what)} ${"over18" if thing.over_18 else ""} ${thing.visited and 'visited' or ''}
+${parent.thing_css_class(what)} ${"over18" if thing.over_18 else ""} ${thing.visited and 'visited' or ''} ${"archived" if not getattr(thing, "votable", True)}
 %if c.user.pref_show_link_flair and (thing.flair_text or thing.flair_css_class):
   <% css = thing.flair_css_class or '' %>
   linkflair ${' '.join('linkflair-' + c for c in css.split())}


### PR DESCRIPTION
www.reddit.com complement to 4a9d45a878cceb27c01f67eda658c72f2579f298

If a post cannot be voted upon, then render it as `<div class="thing ... archived">` in post listings or `<body class="single-page ... archived">` on its single-page view.

Subreddit stylesheets, user stylesheets, and browser extensions can take advantage of this by hiding unusable features such as up/down vote buttons or adding warning banners/tooltips.

---

This is untested, so I hope I put enough things in the right places and no things in the wrong ones.