### PR TITLE
Fix uri & extensions of the `/duplicates` endpoint

### DIFF
--- a/r2/r2/controllers/front.py
+++ b/r2/r2/controllers/front.py
@@ -820,7 +820,7 @@ class FrontController(RedditController):
     @base_listing
     @require_oauth2_scope("read")
     @validate(article=VLink('article'))
-    @api_doc(api_section.listings, uri="/{article}/duplicates")
+    @api_doc(api_section.listings, uri="/duplicates/{article}", extensions=['json', 'xml'])
     def GET_duplicates(self, article, num, after, reverse, count):
         """Return a list of other submissions of the same URL"""
         if not can_view_link_comments(article):


### PR DESCRIPTION
The order was backwards. 

```
/{article}/duplicates --> /duplicates/{article}
```

Switched the order, and added in the proper extensions.

Referenced in: https://www.reddit.com/r/redditdev/comments/2vbnkt/sample_curl_call_for_articleduplicates/