### PR TITLE
Add missing extensions to info endpoint in API docs

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -173,7 +173,11 @@ class ApiController(RedditController):
         things=VByName('id', multiple=True, limit=100),
         url=VUrl('url'),
     )
-    @api_doc(api_section.links_and_comments, uses_site=True)
+    @api_doc(
+        api_section.links_and_comments, 
+        uses_site=True, 
+        extensions=['json', 'xml']
+    )
     def GET_info(self, things, url):
         """
         Return a listing of things specified by their fullnames.


### PR DESCRIPTION
The endpoint [GET [**/r/**_subreddit_]**/api/info**](https://www.reddit.com/dev/api#GET_api_info) is missing the extensions `[ .json | .xml ]`

Discussed in https://github.com/trevorsenior/snoocore/issues/92