### PR TITLE
Change /{article}/related to /related/{article} in API docs

### DIFF
--- a/r2/r2/controllers/front.py
+++ b/r2/r2/controllers/front.py
@@ -788,7 +788,7 @@ class FrontController(RedditController):
     @base_listing
     @require_oauth2_scope("read")
     @validate(article=VLink('article'))
-    @api_doc(api_section.listings, uri="/{article}/related")
+    @api_doc(api_section.listings, uri="/related/{article}")
     def GET_related(self, num, article, after, reverse, count):
         """Related page: performs a search using title of article as
         the search query.


### PR DESCRIPTION
There's an error in the API docs. This is a github edit, so I didn't do any testing, but I'm guessing this is correct.