### PR TITLE
Fix NameError when populating db.

### DIFF
--- a/r2/r2/lib/cache.py
+++ b/r2/r2/lib/cache.py
@@ -40,6 +40,8 @@ from r2.lib.hardcachebackend import HardCacheBackend
 from r2.lib.sgm import sgm # get this into our namespace so that it's
                            # importable from us
 
+import random
+                           
 # This is for use in the health controller
 _CACHE_SERVERS = set()
 
@@ -924,7 +926,6 @@ class CassandraCache(CacheUtils):
         return ret
 
     def _warm(self, keys):
-        import random
         if False and random.random() > 0.98:
             print 'Warming', keys
             self.cf.multiget(keys)


### PR DESCRIPTION
- Included `import random` at the top of r2/r2/lib/cache.py
- Removed `import random`'s that appear in r2/r2/lib/cache.py function definitions.

There are several usages of `random.random()` in function definitions that do not first `import random`. When populating the database for the first time it throws a NameError:

```
>>> from r2.models import populatedb
>>> populatedb.populate()
```

NameError: global name 'random' is not defined

By moving `import random` to the global scope of the file this error is removed.