### PR TITLE
Fix hidden scores appearing in recently viewed links

### DIFF
--- a/r2/r2/templates/link.htmllite
+++ b/r2/r2/templates/link.htmllite
@@ -98,7 +98,10 @@
        >
       %if not expanded:
       <%
-       score_dislikes, score_unvoted, score_likes = thing.display_score
+       if thing.hide_score:
+           score_dislikes = score_unvoted = score_likes = unsafe('&bull; points')
+       else:
+           score_dislikes, score_unvoted, score_likes = thing.display_score
        %>
       <span class="score dislikes" ${hide_if_appropriate('dislikes')}>
          ${score_dislikes}


### PR DESCRIPTION
The hidden scores of new posts are currently visible in the 'recently viewed links' view. This replaces a score that should be hidden with the generic value: &bull; points