### PR TITLE
Bug fix for stylsheet edit page

### DIFF
--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -4391,8 +4391,8 @@ ul#image-preview-list li {
     vertical-align: top; 
     width: 45%; 
     height: 100px; 
-    float: left;
     position: relative; 
+	display: inline-block;
 }
 
 ul#image-preview-list .preview {


### PR DESCRIPTION
Fix an issue where the content div would clip over the stylsheet image
display section.  Only noticeable when the content background is set to
a different color from the body background.