### PR TITLE
API: Add support for JSON responses from /api/subreddit_stylesheet

### DIFF
--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -1066,6 +1066,7 @@ class StylesheetTemplate(ThingJsonTemplate):
     _data_attrs_ = dict(
         images='_images',
         stylesheet='stylesheet_contents',
+        url='_url',
         subreddit_id='_fullname',
     )
 
@@ -1086,7 +1087,13 @@ class StylesheetTemplate(ThingJsonTemplate):
             return self.images()
         elif attr == '_fullname':
             return c.site._fullname
+        elif attr == '_url':
+            return c.site.stylesheet_url
         return ThingJsonTemplate.thing_attr(self, thing, attr)
+
+class EditStylesheetTemplate(ThingJsonTemplate):
+    def render(self, thing, *a, **kw):
+        return ObjectTemplate(thing)
 
 class SubredditSettingsTemplate(ThingJsonTemplate):
     _data_attrs_ = dict(
@@ -1145,6 +1152,8 @@ class SubredditSettingsTemplate(ThingJsonTemplate):
 class UploadedImageJsonTemplate(JsonTemplate):
     def render(self, thing, *a, **kw):
         return ObjectTemplate({
+            "modhash": c.modhash if c.modhash else '',
+            "status": thing.status,
             "errors": list(k for (k, v) in thing.errors if v),
             "img_src": thing.img_src,
         })


### PR DESCRIPTION
Previously, the only response one could get from reddit when submitting a stylesheet is the difficult-to-parse one intended for reddit's jQuery pseudo-eval library.

This commit also adds "modhash" to the response from `/api/upload_sr_img.json`, and adds "url" to the response from `/about/stylesheet.json`; Additionally, the `.json` variants of `/api/subreddit_stylesheet` and `/api/upload_sr_img.json` have been added to the docs as they're the only way to use these methods while in a browser userscript. (that I've found, at least)