### PR TITLE
Make date format localizable after "this post was submitted on"

### DIFF
--- a/r2/r2/lib/template_helpers.py
+++ b/r2/r2/lib/template_helpers.py
@@ -32,6 +32,7 @@ from r2.lib.static import static_mtime
 from r2.lib import js
 
 import babel.numbers
+import babel.dates
 import simplejson
 import os.path
 from copy import copy
@@ -590,6 +591,11 @@ def format_number(number, locale=None):
 
 def format_percent(ratio, locale=None):
     return babel.numbers.format_percent(ratio, locale=locale or c.locale)
+
+
+def format_date(date, locale=None):
+    return babel.dates.format_date(date, _("dd MMM yyyy"),
+                                   locale=locale or c.locale)
 
 
 def html_datetime(date):

--- a/r2/r2/templates/linkinfobar.html
+++ b/r2/r2/templates/linkinfobar.html
@@ -39,7 +39,7 @@
       &#32;
     </span>
     <time datetime="${html_datetime(thing.a._date)}">
-      ${thing.a._date.strftime(thing.datefmt)}
+      ${thing.a._date.strftime(_('%d %b %Y'))}
     </time>
   </div>
 

--- a/r2/r2/templates/linkinfobar.html
+++ b/r2/r2/templates/linkinfobar.html
@@ -23,7 +23,8 @@
 <%!
    from r2.lib.filters import websafe
    from r2.lib.strings import Score
-   from r2.lib.template_helpers import format_number, format_percent, html_datetime
+   from r2.lib.template_helpers import (
+       format_number, format_percent, format_date, html_datetime)
  %>
 
 
@@ -39,7 +40,7 @@
       &#32;
     </span>
     <time datetime="${html_datetime(thing.a._date)}">
-      ${thing.a._date.strftime(_('%d %b %Y'))}
+      ${format_date(thing.a._date)}
     </time>
   </div>
 


### PR DESCRIPTION
Current translation doesn't affect thing.datefmt (it's always "%d %b %Y"), so I changed it so that the format string is translated immediately.