### PR TITLE
Use <bdi></bdi> HTML tags to fix ordering in RTL direction

### DIFF
--- a/r2/r2/templates/comment.html
+++ b/r2/r2/templates/comment.html
@@ -84,7 +84,7 @@ ${parent.midcol(cls = cls)}
      %if thing.deleted:
        <em>${_("deleted comment from")}</em>&#32;
      %endif
-     ${WrappedUser(thing.author, thing.attribs, thing)}
+     <bdi>${WrappedUser(thing.author, thing.attribs, thing)}</bdi>
      &#32;
   %else:
      <em>${_("[deleted]")}</em>&#32;

--- a/r2/r2/templates/redditheader.html
+++ b/r2/r2/templates/redditheader.html
@@ -79,7 +79,7 @@
     %else:
       <span class="user">
          ${plain_link(c.user.name, "/user/%s/" % c.user.name, _sr_path=False)}
-         &nbsp;(<span class="userkarma" title="${_("link karma")}">${display_link_karma(c.user.link_karma)}</span>)
+         &nbsp;<bdi>(<span class="userkarma" title="${_("link karma")}">${display_link_karma(c.user.link_karma)}</span>)</bdi>
       </span>
 
       ${separator("|")}


### PR DESCRIPTION
Without those, instead of "(1) user" you get "(user (1"
Instead of "user[S]" you get "[user[S".