### PR TITLE
Add SVG support to custom images

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -91,7 +91,7 @@ from r2.lib import tracking, emailer
 from r2.lib.subreddit_search import search_reddits
 from r2.lib.log import log_text
 from r2.lib.filters import safemarkdown
-from r2.lib.media import str_to_image
+from r2.lib.media import str_to_image, svg_size
 from r2.controllers.api_docs import api_doc, api_section
 from r2.lib.search import SearchQuery
 from r2.controllers.oauth2 import require_oauth2_scope, allow_oauth2_access
@@ -2235,7 +2235,7 @@ class ApiController(RedditController):
         * If the `header` field has value `1`, then `upload_type` is `header`.
 
         The `img_type` field specifies whether to store the uploaded image as a
-        PNG or JPEG.
+        PNG, JPEG or SVG.
 
         Subreddits have a limited number of images that can be in use at any
         given time. If no image with the specified name already exists, one of
@@ -2272,7 +2272,10 @@ class ApiController(RedditController):
                 errors['IMAGE_ERROR'] = _("too many images (you only get %d)") % g.max_sr_images
 
         try:
-            size = str_to_image(file).size
+            if img_type == "svg":
+                size = svg_size(file)
+            else:
+                size = str_to_image(file).size
         except (IOError, TypeError):
             errors['IMAGE_ERROR'] = _('Invalid image or general image error')
         else:

--- a/r2/r2/lib/validator/validator.py
+++ b/r2/r2/lib/validator/validator.py
@@ -2041,13 +2041,13 @@ class VLocation(Validator):
 
 class VImageType(Validator):
     def run(self, img_type):
-        if not img_type in ('png', 'jpg'):
+        if not img_type in ('png', 'jpg', 'svg'):
             return 'png'
         return img_type
 
     def param_docs(self):
         return {
-            self.param: "one of `png` or `jpg` (default: `png`)",
+            self.param: "one of `png`, `jpg` or `svg` (default: `png`)",
         }
 
 

--- a/r2/r2/templates/subredditstylesheet.html
+++ b/r2/r2/templates/subredditstylesheet.html
@@ -184,7 +184,7 @@
                 var ext = file_input.value
                     .split('.').pop().toLowerCase()
                     .replace("jpeg", "jpg");
-                if (ext == 'png' || ext == 'jpg') {
+                if (ext == 'png' || ext == 'jpg' || ext == 'svg') {
                     $('input:radio[name=img_type]').attr('checked', false);
                     $('input:radio[name=img_type][value="' + ext + '"]').attr('checked', true);
                 }

--- a/r2/r2/templates/utils.html
+++ b/r2/r2/templates/utils.html
@@ -313,6 +313,8 @@ ${unsafe(txt)}
             <label><input type="radio" name="img_type" value="jpg" />JPEG</label>
             &nbsp;&nbsp;
             <label><input type="radio" name="img_type" checked value="png" />PNG</label>
+            &nbsp;&nbsp;
+            <label><input type="radio" name="img_type" value="svg" />SVG</label>
             <br/>
           %endif
           <input type="file" name="file" id="file" 


### PR DESCRIPTION
SVG support for subreddit stylesheets allows reddit to move forward into the future of high-resolution displays, because scalability is key.

In making this change, there are a number of security issues that need to be considered with relation to SVG and XML files that may be uploaded to a server, especially one the size of reddit. As such, this change employs a whitelist of allowable tags and attributes (much like the CSS validator), and takes all necessary steps to make the SVGs are secure as possible.

The program, when tested on [my own server](http://50.116.12.143/), correctly sanitised each and every vulnerability on the [HTML5Sec page](https://html5sec.org/#svg) that was listed under SVG _and_ XML. That being said, I would be happy to aid any additional security testing in any way that I can.

I also have a wiki page ready, which would outline the best practices for submitting an SVG file, because there are some nuances which could involve sacrificing SVG functionality that might confuse the user. The draft is at [this link](https://gist.github.com/huw/0cfd95695c2829f372ea).

Looking forward to hearing from you guys, this is a change which I really hope we can implement 😊