### PR TITLE
Added AutoModerator to the config permission tooltip

### DIFF
--- a/r2/r2/lib/app_globals.py
+++ b/r2/r2/lib/app_globals.py
@@ -561,7 +561,7 @@ class Globals(object):
         # the main memcache pool. used for most everything.
         memcache = CMemcache(
             self.memcaches,
-            min_compress_len=50 * 1024,
+            min_compress_len=1400,
             num_clients=num_mc_clients,
             binary=True,
         )

--- a/r2/r2/lib/permissions.py
+++ b/r2/r2/lib/permissions.py
@@ -78,7 +78,7 @@ class ModeratorPermissionSet(PermissionSet):
         ),
         config=dict(
             title=N_('config'),
-            description=N_('edit settings, sidebar, css, images, and AutoModerator'),
+            description=N_('edit settings, sidebar, css, images, and automoderator'),
         ),
         flair=dict(
             title=N_('flair'),

--- a/r2/r2/lib/permissions.py
+++ b/r2/r2/lib/permissions.py
@@ -78,7 +78,7 @@ class ModeratorPermissionSet(PermissionSet):
         ),
         config=dict(
             title=N_('config'),
-            description=N_('edit settings, sidebar, css, images, and automoderator'),
+            description=N_('edit settings, sidebar, css, images, and AutoModerator config'),
         ),
         flair=dict(
             title=N_('flair'),


### PR DESCRIPTION
The config permission now has the ability to manage AutoModerator, so the tooltip should reflect this.