### PR TITLE
Added "theme-color" meta element to layout

### DIFF
--- a/r2/r2/templates/base.compact
+++ b/r2/r2/templates/base.compact
@@ -42,6 +42,7 @@
     <meta name="title" content="${self.Title()}" />
     <meta name="description" content="${thing.short_description or g.short_description}" />
     <meta name="referrer" content="${c.referrer_policy}" />
+    <meta name="theme-color" content="#cee3f8">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     ${self.robots()}
     <link rel="stylesheet" href="${static('compact.css')}" type="text/css" media="screen" />

--- a/r2/r2/templates/base.html
+++ b/r2/r2/templates/base.html
@@ -34,6 +34,7 @@
     <meta name="keywords" content="${self.keywords()}" />
     <meta name="description" content="${getattr(thing, 'short_description', None) or g.short_description}" />
     <meta name="referrer" content="${c.referrer_policy}">
+    <meta name="theme-color" content="#cee3f8">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     %if hasattr(thing, 'mobile_link'):
         <link rel="alternate" media="only screen and (max-width: 640px)" href="${thing.mobile_link}" />


### PR DESCRIPTION
Added a "theme-color" meta element to base layouts.
This will make the address and status bar bluish on Chrome in Android Lollipop.