### PR TITLE
Perserve the originally attempted title when resubmitting a link.

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -520,7 +520,7 @@ class ApiController(RedditController):
                 if links:
                     c.errors.add(errors.ALREADY_SUB, field='url')
                     form.has_errors('url', errors.ALREADY_SUB)
-                    u = links[0].already_submitted_link(url)
+                    u = links[0].already_submitted_link(url, title)
                     if extension:
                         u = UrlParser(u)
                         u.set_extension(extension)

--- a/r2/r2/controllers/front.py
+++ b/r2/r2/controllers/front.py
@@ -287,7 +287,8 @@ class FrontController(RedditController):
         infotext = None
         if request.GET.get('already_submitted'):
             submit_url = request.GET.get('submit_url') or article.url
-            resubmit_url = Link.resubmit_link(submit_url)
+            submit_title = request.GET.get('submit_title') or ""
+            resubmit_url = Link.resubmit_link(submit_url, submit_title)
             if c.user_is_loggedin and c.site.can_submit(c.user):
                 resubmit_url = add_sr(resubmit_url)
             infotext = strings.already_submitted % resubmit_url
@@ -1225,12 +1226,13 @@ class FrontController(RedditController):
 
             if links and len(links) == 1:
                 # redirect the user to the existing link's comments
-                existing_submission_url = links[0].already_submitted_link(url)
+                existing_submission_url = links[0].already_submitted_link(url,
+                                                                          title)
                 return self.redirect(existing_submission_url)
             elif links:
                 # show the user a listing of all the other links with this url
                 # an infotext to resubmit it
-                resubmit_url = Link.resubmit_link(url)
+                resubmit_url = Link.resubmit_link(url, title)
                 sr_resubmit_url = add_sr(resubmit_url)
                 infotext = strings.multiple_submitted % sr_resubmit_url
                 res = BoringPage(

--- a/r2/r2/models/link.py
+++ b/r2/r2/models/link.py
@@ -177,16 +177,17 @@ class Link(Thing, Printable):
             LinksByUrl._set_values(LinksByUrl._key_from_url(self.url),
                                    {self._id36: ''})
 
-    def already_submitted_link(self, url):
+    def already_submitted_link(self, url, title):
         permalink = self.make_permalink_slow()
         p = UrlParser(permalink)
-        p.update_query(already_submitted="true", submit_url=url)
+        p.update_query(already_submitted="true", submit_url=url,
+                       submit_title=title)
         return p.unparse()
 
     @classmethod
-    def resubmit_link(cls, url):
+    def resubmit_link(cls, url, title):
         p = UrlParser("/submit")
-        p.update_query(resubmit="true", url=url)
+        p.update_query(resubmit="true", url=url, title=title)
         return p.unparse()
 
     @classmethod


### PR DESCRIPTION
Hello!  /u/pokechu22 here.  I've added support for saving the current title when resubmitting a link, in the same way that 1c8a271 did with the full URL.  