### PR TITLE
Changed color of preference update success message

### DIFF
--- a/r2/r2/templates/prefoptions.html
+++ b/r2/r2/templates/prefoptions.html
@@ -89,7 +89,7 @@
 
 %if c.user_is_loggedin:
   %if thing.done:
-    <p class="error">${_("your preferences have been updated")}</p>
+    <p class="green">${_("your preferences have been updated")}</p>
   %elif thing.error_style_override:
     <p class="error">${_("we couldn't save the custom stylesheet preference. please see the error below")}</p>
   %elif thing.generic_error:


### PR DESCRIPTION
If your preferences were successfully updated, the message saying so shouldn't be colored red like an error message.