### PR TITLE
Fixed uneven padding on nsfw-stamp

### DIFF
--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -4686,7 +4686,7 @@ form input[type=radio] {margin: 2px .5em 0 0; }
 .over18 button { margin: 0 10px 0 10px; padding: 5px}
 
 .entry .buttons li.nsfw-stamp {
-    padding-left: 2px;
+    padding-right: 2px;
     font-size: x-small;
 }
 


### PR DESCRIPTION
On NSFW-stamps, left padding was 2px while right padding was 4px. Changed right to 2px.