### PR TITLE
Fixes the overflow of AM conditions, turns them into paragraphs.

### DIFF
--- a/r2/r2/public/static/css/wiki.less
+++ b/r2/r2/public/static/css/wiki.less
@@ -174,5 +174,8 @@
 // Specific wiki page styles
 .wiki-page-config-automoderator #editform textarea {
   font-family: "Bitstream Vera Sans Mono", Consolas, monospace;
-  word-wrap: break-word;
+}
+div.wiki-page-content.md-container .pre{
+    word-wrap: break-word;
+    white-space: pre-wrap;
 }

--- a/r2/r2/public/static/css/wiki.less
+++ b/r2/r2/public/static/css/wiki.less
@@ -174,4 +174,5 @@
 // Specific wiki page styles
 .wiki-page-config-automoderator #editform textarea {
   font-family: "Bitstream Vera Sans Mono", Consolas, monospace;
+  word-wrap: break-word;
 }


### PR DESCRIPTION
AM condition text was overflowing to the right side of the page, this just fixes it so it all is shown nicely in normal paragraph form.