### PR TITLE
Guard against RES expandos

### DIFF
--- a/r2/r2/public/static/js/expando.js
+++ b/r2/r2/public/static/js/expando.js
@@ -18,6 +18,11 @@
     },
 
     toggleExpando: function(e) {
+      // temporary fix for RES http://redd.it/392zol
+      if (!$this.$button.is(e.target)) {
+        return;
+      }
+      
       this.expanded ? this.collapse() : this.expand();
     },
 

--- a/r2/r2/public/static/js/expando.js
+++ b/r2/r2/public/static/js/expando.js
@@ -55,6 +55,11 @@
 
   $(function() {
     $('.link-listing').on('click', '.expando-button', function(e) {
+      if (e.target.tagName === 'DIV')) {
+        // temporary fix for RES http://redd.it/392zol
+        // RES uses <a class="expando-button" />
+        return;
+      }
       var $thing = $(this).closest('.thing')
 
       if ($thing.data('expando')) {

--- a/r2/r2/public/static/js/expando.js
+++ b/r2/r2/public/static/js/expando.js
@@ -54,10 +54,16 @@
   });
 
   $(function() {
-    var expandoThings = $('.expando-button').closest('.thing');
+    $('.link-listing').on('click', '.expando-button', function(e) {
+      var $thing = $(this).closest('.thing')
 
-    expandoThings.each(function() {
-      new ExpandoLink({ el: this });
+      if ($thing.data('expando')) {
+        return;
+      }
+
+      $thing.data('expando', true);
+      var view = new ExpandoLink({ el: $thing[0] });
+      view.toggleExpando(e);
     });
   });
 }(r);


### PR DESCRIPTION
RES adds posts after page load and adds expandos next to reddit's expandos or inside self-post expandos. This leads to some reddit's expandos not getting a view, or RES's expandos being confused for reddit's expandos.  

This PR adds some guards and handling to address this.

**This PR has not been tested.**