### PR TITLE
Perserve selected search syntax when updating query and provide a link to search in the converted syntax in the δ

### DIFF
--- a/r2/r2/controllers/front.py
+++ b/r2/r2/controllers/front.py
@@ -1158,10 +1158,12 @@ class FrontController(RedditController):
         query = q.query
         recent = q.recent
         sort = q.sort
+        syntax = q.syntax
         def wrapper_fn(thing):
             thing.prev_search = query
             thing.recent = recent
             thing.sort = sort
+            thing.syntax = syntax
             w = Wrapped(thing)
             if isinstance(thing, Link):
                 w.render_class = SearchResultLink

--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -1450,8 +1450,9 @@ class SearchPage(BoringPage):
             kw['nav_menus'].append(MenuLink(title=_('enable NSFW results'),
                                             url=over18_url))
 
-        self.sr_facets = SubredditFacets(prev_search=prev_search, facets=facets,
-                                         sort=sort, recent=recent)
+        self.sr_facets = SubredditFacets(prev_search=prev_search,
+                                         facets=facets, sort=sort,
+                                         recent=recent, syntax=syntax)
         BoringPage.__init__(self, pagename, robots='noindex', *a, **kw)
 
     def content(self):
@@ -3249,10 +3250,12 @@ class SearchBar(Templated):
 
 
 class SubredditFacets(Templated):
-    def __init__(self, prev_search='', facets={}, sort=None, recent=None):
+    def __init__(self, prev_search='', facets={}, sort=None, recent=None,
+                 syntax=None):
         self.prev_search = prev_search
 
-        Templated.__init__(self, facets=facets, sort=sort, recent=recent)
+        Templated.__init__(self, facets=facets, sort=sort, recent=recent,
+                           syntax=syntax)
 
 
 class NewLink(Templated):

--- a/r2/r2/lib/template_helpers.py
+++ b/r2/r2/lib/template_helpers.py
@@ -563,7 +563,9 @@ def add_attr(attrs, kind, label=None, link=None, cssclass=None, symbol=None):
     attrs.append( (priority, symbol, cssclass, label, link) )
 
 
-def search_url(query, subreddit, restrict_sr="off", sort=None, recent=None, ref=None):
+def search_url(
+        query, subreddit, restrict_sr="off", sort=None, recent=None, ref=None,
+        syntax=None):
     import urllib
     query = _force_utf8(query)
     url_query = {"q": query}
@@ -575,6 +577,8 @@ def search_url(query, subreddit, restrict_sr="off", sort=None, recent=None, ref=
         url_query["sort"] = sort
     if recent:
         url_query["t"] = recent
+    if syntax:
+        url_query["syntax"] = syntax
     path = "/r/%s/search?" % subreddit if subreddit else "/search?"
     path += urllib.urlencode(url_query)
     return path

--- a/r2/r2/templates/searchbar.html
+++ b/r2/r2/templates/searchbar.html
@@ -25,7 +25,17 @@
     <div>
     <p class="debuginfo">
       <span class="icon">&delta;</span>&nbsp;
-      <span class="content">${_('converted query to %(syntax)s syntax: %(converted)s') % thing.converted_data}</span>
+      <span class="content">  
+        ${plain_link(  
+            _('converted query to %(syntax)s syntax: %(converted)s') % thing.converted_data,
+            search_url(converted_data["converted"], thing.name,
+                       restrict_sr=thing.restrict_sr, sort=thing.sort,
+                       recent=thing.recent, syntax=converted_data["syntax"]),
+            sr_path=False,
+            cname=False,
+            title=_('switch to %(syntax)s syntax' % thing.converted_data)
+        )}
+      </span>
     </p>
     </div>
   </div>

--- a/r2/r2/templates/searchform.html
+++ b/r2/r2/templates/searchform.html
@@ -93,4 +93,8 @@
   %for k, v in thing.search_params.iteritems():
     <input type="hidden" name="${k}" value="${v}">
   %endfor
+  
+  %if thing.syntax: 
+    <input type="hidden" name="syntax" value="${thing.syntax}"> 
+  %endif
 </form>

--- a/r2/r2/templates/searchresultsubreddit.html
+++ b/r2/r2/templates/searchresultsubreddit.html
@@ -81,7 +81,8 @@
     ${self.search_result_icon('filter')}
     ${plain_link(
         _("search within %(subreddit)s") % dict(subreddit=pretty_name),
-        search_url(thing.prev_search, thing.name, restrict_sr='on', sort=thing.sort, recent=thing.recent),
+        search_url(thing.prev_search, thing.name, restrict_sr='on', 
+                   sort=thing.sort, recent=thing.recent, syntax=thing.syntax),
         sr_path=False,
         cname=False,
         _class='search-link',

--- a/r2/r2/templates/subredditfacets.html
+++ b/r2/r2/templates/subredditfacets.html
@@ -30,7 +30,7 @@
   <ol class="list">
   %for subreddit, count in thing.facets:
     <li class="searchfacet reddit">
-      <a class="facet title word" href="${search_url(thing.prev_search, subreddit.name, restrict_sr='on', sort=thing.sort, recent=thing.recent, ref='search_facets')}">/r/${subreddit.name}</a>&nbsp;
+      <a class="facet title word" href="${search_url(thing.prev_search, subreddit.name, restrict_sr='on', sort=thing.sort, recent=thing.recent, ref='search_facets', syntax=thing.syntax)}">/r/${subreddit.name}</a>&nbsp;
       <span class="facet count number">(${count})</span>
     </li>&nbsp;
   %endfor


### PR DESCRIPTION
This makes it easier to search in alternate syntaxes (such as cloudsearch) by doing 2 things: 

1. Preserving the entered search syntax (rather than setting it back to default each search)
2. Making the &delta; (delta) icon have a link to search in the converted syntax.

*This code is untested*.