### PR TITLE
Add hidden #night-mode checkbox beneath <body>

### DIFF
--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -11171,3 +11171,5 @@ body:not(.loggedin) .reply-button,
 body:not(.loggedin) .report-button {
     display: none;
 }
+
+#night-mode{display: none;}

--- a/r2/r2/templates/base.html
+++ b/r2/r2/templates/base.html
@@ -60,6 +60,7 @@
   </head>
 
   <body ${classes(*thing.page_classes())}>
+    <input type="checkbox" id='night-mode'>
     ${self.bodyContent()}
     ${self.javascript_bottom()}
   </body>


### PR DESCRIPTION
The goal is to eventually let subreddits create their own night-mode themes. This just adds a (hidden) checkbox beneath the body tag. The checkbox itself doesn't do anything, it just gets used in a selector.

You can style things based on whether or not the checkbox is selected. As an example,

    #night-mode:selected ~ * .usertext-body

would select the usertest-body class only when the night mode checkbox is checked.

The impact is minimal, two lines of front-end code. Down the line, we add a label for that button, and store it's state and default user-preference.

If this goes over well, I'll look into getting a dev enviroment set up and doing those changes.