### PR TITLE
Don't send Cache-Control: no-cache, just do private and max-age=0

### DIFF
--- a/r2/r2/controllers/reddit_base.py
+++ b/r2/r2/controllers/reddit_base.py
@@ -1224,7 +1224,12 @@ class MinimalController(BaseController):
         would_poison = any((k not in CACHEABLE_COOKIES) for k in dirty_cookies)
 
         if c.user_is_loggedin or would_poison:
-            response.headers['Cache-Control'] = 'private, no-cache'
+            # Don't send no-cache, with https browsers will refresh the page when
+            # the back button is used and no-cache is set. Instead use private and
+            # max-age=0 to prevent proxies from caching the result but allowing the
+            # browser to cache it for the back button. When the page is refreshed
+            # in another way the max-age=0 makes the browser send a new request.
+            response.headers['Cache-Control'] = 'private, max-age=0'
             response.headers['Pragma'] = 'no-cache'
 
         # save the result of this page to the pagecache if possible.  we


### PR DESCRIPTION
Now that reddit has fully switched to https I have noticed the annoyance that each time I click a link, then click the back button reddit will refresh the page instead of using the cache like a normal website does when you use the back button.

This is because reddit is sending a Cache-Control: no-cache header. A long time ago browsers decided that if an https page sends this it shouldn't use a cached copy on the back button because of some compatibility issues with some bank websites: https://bugzilla.mozilla.org/show_bug.cgi?id=567365

For this reason other big sites like [news.ycombinator.com](https://news.ycombinator.com) use a Cache-Control: private, max-age=0 so proxies don't cache the response, browsers don't cache it on a page refresh, but the browser is still allowed to cache the page for the back button: http://www.w3.org/Protocols/HTTP/Issues/cache-private.html

I think it's good if reddit also does this. This would mean a better experience for people that don't open links in tabs but instead use the back button. It would probably also lower the amount of requests reddit gets by a bit.