### PR TITLE
Add message to be used for when a subreddit is set to private.

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -2527,6 +2527,7 @@ class ApiController(RedditController):
 
         kw = {k: v for k, v in kw.iteritems() if k in keyword_fields}
 
+        private_message = kw.pop('private_message')
         public_description = kw.pop('public_description')
         description = kw.pop('description')
         submit_text = kw.pop('submit_text')
@@ -2555,6 +2556,14 @@ class ApiController(RedditController):
                 'config/description',
                 public_description,
                 'public_description',
+            )
+
+            apply_wikid_field(
+                sr,
+                form,
+                'config/private_message',
+                private_message,
+                'private_message',
             )
         
         if not sr and not c.user.can_create_subreddit:

--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -2405,6 +2405,7 @@ class ApiController(RedditController):
                    domain = VCnameDomain("domain"),
                    submit_text = VMarkdownLength("submit_text", max_length=1024),
                    public_description = VMarkdownLength("public_description", max_length = 500),
+                   private_message = VMarkdownLength("private_message", max_length=500),
                    description = VMarkdownLength("description", max_length = 5120),
                    lang = VLang("lang"),
                    over_18 = VBoolean('over_18'),
@@ -2502,6 +2503,7 @@ class ApiController(RedditController):
             'link_type',
             'name',
             'over_18',
+            'private_message',
             'public_description',
             'public_traffic',
             'related_subreddits',
@@ -2619,7 +2621,8 @@ class ApiController(RedditController):
                               errors.INVALID_OPTION) or
               form.has_errors(('public_description',
                                'submit_text',
-                               'description'), errors.TOO_LONG)):
+                               'description',
+                               'private_message'), errors.TOO_LONG)):
             pass
         elif (form.has_errors(('wiki_edit_karma', 'wiki_edit_age'), 
                               errors.BAD_NUMBER)):

--- a/r2/r2/controllers/reddit_base.py
+++ b/r2/r2/controllers/reddit_base.py
@@ -1663,16 +1663,16 @@ class RedditController(OAuth2ResourceController):
             # is sent in those cases - just a set of headers
             if (not c.site.can_view(c.user) and not c.error_page and
                     request.method != "OPTIONS"):
+                private_message = c.site.private_message
                 if isinstance(c.site, LabeledMulti):
                     # do not leak the existence of multis via 403.
                     self.abort404()
                 elif c.site.type == 'gold_only' and not (c.user.gold or c.user.gold_charter):
-                    public_description = c.site.public_description
                     errpage = pages.RedditError(
                         strings.gold_only_subreddit_title,
                         strings.gold_only_subreddit_message,
                         image="subreddit-gold-only.png",
-                        sr_description=public_description,
+                        sr_description=private_message,
                     )
                     request.environ['usable_error_content'] = errpage.render()
                     self.abort403()
@@ -1682,7 +1682,7 @@ class RedditController(OAuth2ResourceController):
                         strings.private_subreddit_title,
                         strings.private_subreddit_message,
                         image="subreddit-private.png",
-                        sr_description=message,
+                        sr_description=private_message,
                     )
                     request.environ['usable_error_content'] = errpage.render()
                     self.abort403()

--- a/r2/r2/controllers/reddit_base.py
+++ b/r2/r2/controllers/reddit_base.py
@@ -1677,12 +1677,12 @@ class RedditController(OAuth2ResourceController):
                     request.environ['usable_error_content'] = errpage.render()
                     self.abort403()
                 else:
-                    public_description = c.site.public_description
+                    message = c.site.private_message
                     errpage = pages.RedditError(
                         strings.private_subreddit_title,
                         strings.private_subreddit_message,
                         image="subreddit-private.png",
-                        sr_description=public_description,
+                        sr_description=message,
                     )
                     request.environ['usable_error_content'] = errpage.render()
                     self.abort403()

--- a/r2/r2/controllers/wiki.py
+++ b/r2/r2/controllers/wiki.py
@@ -88,14 +88,17 @@ page_descriptions = {
     "config/sidebar": _("The contents of this page appear on the subreddit sidebar"),
     "config/description": _("The contents of this page appear in the public subreddit description"),
     "config/automoderator": _("This page is used to configure AutoModerator for the subreddit, please see [the full documentation](/wiki/automoderator/full-documentation) for information"),
+    "config/private_message": _("This contents of this page appear when the user does not have access to a private subreddit"),
 }
 
 ATTRIBUTE_BY_PAGE = {"config/sidebar": "description",
                      "config/submit_text": "submit_text",
-                     "config/description": "public_description"}
+                     "config/description": "public_description",
+                     "config/private_message": "private_message"}
 RENDERERS_BY_PAGE = {
     "config/automoderator": "automoderator",
     "config/description": "reddit",
+    "config/private_message": "reddit",
     "config/sidebar": "reddit",
     "config/stylesheet": "stylesheet",
     "config/submit_text": "reddit",

--- a/r2/r2/controllers/wiki.py
+++ b/r2/r2/controllers/wiki.py
@@ -88,7 +88,7 @@ page_descriptions = {
     "config/sidebar": _("The contents of this page appear on the subreddit sidebar"),
     "config/description": _("The contents of this page appear in the public subreddit description"),
     "config/automoderator": _("This page is used to configure AutoModerator for the subreddit, please see [the full documentation](/wiki/automoderator/full-documentation) for information"),
-    "config/private_message": _("This contents of this page appear when the user does not have access to a private subreddit"),
+    "config/private_message": _("The contents of this page appear when the user does not have access to a private subreddit"),
 }
 
 ATTRIBUTE_BY_PAGE = {"config/sidebar": "description",

--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -292,6 +292,8 @@ class SubredditJsonTemplate(ThingJsonTemplate):
         # key_color="key_color",
         lang="lang",
         over18="over_18",
+        private_message="private_message",
+        private_message_html="private_message_html",
         public_description="public_description",
         public_description_html="public_description_html",
         public_traffic="public_traffic",
@@ -326,7 +328,10 @@ class SubredditJsonTemplate(ThingJsonTemplate):
         "name",
         # Canonical subreddit URL, relative to reddit.com
         "path",
-        # Text shown on the access denied page
+        # Text shown to users who cannot access a subreddit
+        "private_message",
+        "private_message_html",
+        # Public description used for search
         "public_description",
         "public_description_html",
         # Title shown in search
@@ -361,6 +366,8 @@ class SubredditJsonTemplate(ThingJsonTemplate):
             return None
         elif attr == 'description_html':
             return safemarkdown(thing.description)
+        elif attr == 'private_message_html':
+            return safemarkdown(thing.private_message)
         elif attr == 'public_description_html':
             return safemarkdown(thing.public_description)
         elif attr == "is_moderator":

--- a/r2/r2/models/modaction.py
+++ b/r2/r2/models/modaction.py
@@ -137,6 +137,7 @@ class ModAction(tdb_cassandra.UuidThing):
                      # editsettings
                      'title': _('title'),
                      'public_description': _('description'),
+                     'private_message': _('private message'),
                      'description': _('sidebar'),
                      'lang': _('language'),
                      'type': _('type'),

--- a/r2/r2/models/subreddit.py
+++ b/r2/r2/models/subreddit.py
@@ -256,6 +256,7 @@ class Subreddit(Thing, Printable, BaseSite):
         use_quotas=True,
         description="",
         public_description="",
+        private_message="",
         submit_text="",
         allow_gilding=True,
         public_traffic=False,

--- a/r2/r2/models/subreddit.py
+++ b/r2/r2/models/subreddit.py
@@ -900,6 +900,7 @@ class Subreddit(Thing, Printable, BaseSite):
 
     cache_ignore = {
         "description",
+        "private_message",
         "public_description",
         "subscribers",
     }.union(Printable.cache_ignore)

--- a/r2/r2/models/wiki.py
+++ b/r2/r2/models/wiki.py
@@ -57,6 +57,7 @@ restricted_namespaces = ('reddit/', 'config/', 'special/')
 special_pages = {
     'config/automoderator',
     'config/description',
+    'config/private_message',
     'config/sidebar',
     'config/stylesheet',
     'config/submit_text',
@@ -69,6 +70,7 @@ special_page_view_permlevels = {
 # Pages that get created automatically from the subreddit settings page
 automatically_created_pages = {
     'config/description',
+    'config/private_message',
     'config/sidebar',
     'config/stylesheet',
     'config/submit_text',
@@ -79,7 +81,8 @@ special_length_restrictions_bytes = {
     'config/stylesheet': 128*1024,
     'config/submit_text': 1024,
     'config/sidebar': 5120,
-    'config/description': 500
+    'config/description': 500,
+    'config/private_message': 500
 }
 
 modactions = {
@@ -87,6 +90,7 @@ modactions = {
     "config/description": "Updated subreddit description",
     "config/sidebar": "Updated subreddit sidebar",
     "config/submit_text": "Updated submission text",
+    "config/private_message": "Updated private message"
 }
 
 # Page "index" in the subreddit "reddit.com" and a seperator of "\t" becomes:

--- a/r2/r2/templates/createsubreddit.html
+++ b/r2/r2/templates/createsubreddit.html
@@ -88,11 +88,11 @@ try participating in other communities on reddit for a little while first before
     </div>
   </%utils:line_field>
 
-  <%utils:line_field title="${_('private_message')}" css_class="usertext"
-                     description="${_('message to show if this user does not have access to this subreddi. 500 characters max.')}">
+  <%utils:line_field title="${_('private message')}" css_class="usertext"
+                     description="${_('shown if this user does not have access to this subreddit. 500 characters max.')}">
     <div class="usertext-edit md-container">
       <div class="md">
-        <textarea rows="1" cols="1" name="public_description" class="usertext">
+        <textarea rows="1" cols="1" name="private_message" class="usertext">
           %if thing.site and thing.site.private_message:
             ${keep_space(thing.site.private_message or "")}
           %endif

--- a/r2/r2/templates/createsubreddit.html
+++ b/r2/r2/templates/createsubreddit.html
@@ -88,6 +88,19 @@ try participating in other communities on reddit for a little while first before
     </div>
   </%utils:line_field>
 
+  <%utils:line_field title="${_('private_message')}" css_class="usertext"
+                     description="${_('message to show if this user does not have access to this subreddi. 500 characters max.')}">
+    <div class="usertext-edit md-container">
+      <div class="md">
+        <textarea rows="1" cols="1" name="public_description" class="usertext">
+          %if thing.site and thing.site.private_message:
+            ${keep_space(thing.site.private_message or "")}
+          %endif
+        </textarea>
+      </div>
+    </div>
+  </%utils:line_field>
+
   <%utils:line_field title="${_('sidebar')}" css_class="usertext"
                      description="${_('shown in the sidebar of your subreddit. 5120 characters max.')}">
     %if thing.site and thing.site.description:


### PR DESCRIPTION
IdeasForTheAdmins post: https://www.reddit.com/r/ideasfortheadmins/comments/3dgtar/have_a_separate_this_subreddit_is_private_message/

Username on reddit is same as here. Have tested this on a reddit instance and works fine.