### PR TITLE
Add that the description will be used in the private message.

### DIFF
--- a/r2/r2/controllers/wiki.py
+++ b/r2/r2/controllers/wiki.py
@@ -86,7 +86,7 @@ page_descriptions = {
     "config/stylesheet": _("This page is the subreddit stylesheet, changes here apply to the subreddit css"),
     "config/submit_text": _("The contents of this page appear on the submit page"),
     "config/sidebar": _("The contents of this page appear on the subreddit sidebar"),
-    "config/description": _("The contents of this page appear in the public subreddit description"),
+    "config/description": _("The contents of this page appear in the public subreddit description and when the user does not have access to the subreddit"),
     "config/automoderator": _("This page is used to configure AutoModerator for the subreddit, please see [the full documentation](/wiki/automoderator/full-documentation) for information"),
 }
 

--- a/r2/r2/templates/createsubreddit.html
+++ b/r2/r2/templates/createsubreddit.html
@@ -76,7 +76,7 @@ try participating in other communities on reddit for a little while first before
   </%utils:line_field>
 
   <%utils:line_field title="${_('description')}" css_class="usertext"
-                     description="${_('publicly describe your subreddit for all to see. 500 characters max.')}">
+                     description="${_('publicly describe your subreddit for all to see and is shown when a user does not have access. 500 characters max.')}">
     <div class="usertext-edit md-container">
       <div class="md">
         <textarea rows="1" cols="1" name="public_description" class="usertext">

--- a/r2/r2/templates/createsubreddit.html
+++ b/r2/r2/templates/createsubreddit.html
@@ -76,7 +76,7 @@ try participating in other communities on reddit for a little while first before
   </%utils:line_field>
 
   <%utils:line_field title="${_('description')}" css_class="usertext"
-                     description="${_('publicly describe your subreddit for all to see and is shown when a user does not have access. 500 characters max.')}">
+                     description="${_('publicly describe your subreddit for all to see. this is shown when a user does not have access. 500 characters max.')}">
     <div class="usertext-edit md-container">
       <div class="md">
         <textarea rows="1" cols="1" name="public_description" class="usertext">


### PR DESCRIPTION
This changes on the description wiki page and the settings page.

The wiki page is now:

>The contents of this page appear in the public subreddit description and when the user does not have access to the subreddit

where before it was:

>The contents of this page appear in the public subreddit description

and on the settings page:

>publicly describe your subreddit for all to see. 500 characters max.

to:

>publicly describe your subreddit for all to see. this is shown when a user does not have access. 500 characters max.