### PR TITLE
Improving on modtools by giving tb usernotes space

### DIFF
--- a/r2/r2/models/wiki.py
+++ b/r2/r2/models/wiki.py
@@ -60,6 +60,7 @@ special_pages = {
     'config/sidebar',
     'config/stylesheet',
     'config/submit_text',
+    'usernotes')
 }
 
 special_page_view_permlevels = {
@@ -79,7 +80,8 @@ special_length_restrictions_bytes = {
     'config/stylesheet': 128*1024,
     'config/submit_text': 1024,
     'config/sidebar': 5120,
-    'config/description': 500
+    'config/description': 500,
+    'usernotes': 1024*1024
 }
 
 modactions = {


### PR DESCRIPTION
toolbox usernotes often run out of space for subreddits relying heavily on them. These are also the subreddits that form a positive image about reddit since they are often very well moderated. 
This will allow these subreddits to use toolbox usernotes properly.