### PR TITLE
Remove implicate promise from private modmail link

### DIFF
--- a/r2/r2/templates/errorpage.html
+++ b/r2/r2/templates/errorpage.html
@@ -45,7 +45,7 @@ from r2.lib.filters import unsafe, safemarkdown
 
   % if thing.include_message_mods_link:
   <div id="private-subreddit-message-link" class="errorpage-message">
-    <a href="/message/compose/?to=/r/${c.site.name}">${_("send a message to the moderators to request access")}</a>
+    <a href="/message/compose/?to=/r/${c.site.name}">${_("send a message to the moderators")}</a>
   </div>
   % endif
 </div>


### PR DESCRIPTION
> send a message to the moderators to request access

This implies that people can message that sub and get access to it, which often isn't the case. Making it "send a message to the moderators" makes it much more general usage.