### PR TITLE
Make /w/toolbox a "rawcode" page type.

### DIFF
--- a/r2/r2/controllers/wiki.py
+++ b/r2/r2/controllers/wiki.py
@@ -100,6 +100,7 @@ RENDERERS_BY_PAGE = {
     "config/stylesheet": "stylesheet",
     "config/submit_text": "reddit",
     "usernotes": "rawcode",
+    "toolbox": "rawcode",
 }
 
 class WikiController(RedditController):

--- a/r2/r2/controllers/wiki.py
+++ b/r2/r2/controllers/wiki.py
@@ -99,8 +99,8 @@ RENDERERS_BY_PAGE = {
     "config/sidebar": "reddit",
     "config/stylesheet": "stylesheet",
     "config/submit_text": "reddit",
-    "usernotes": "rawcode",
     "toolbox": "rawcode",
+    "usernotes": "rawcode",
 }
 
 class WikiController(RedditController):


### PR DESCRIPTION
Use `rawcode` page type to prevent reddit from rendering /r/sub/w/toolbox (as it's JSON data) as well as reduces bandwidth by not sending `content_html` for JSON requests.

This isn't required or needed for toolbox, but is likely a good idea on reddit's end, since toolbox grabs this page for every subreddit a person moderates.

See also: 3cf7c8534639862dcb1fabce242eefc6a9269f39