### PR TITLE
Add 'quarantine' info to reddit api

### DIFF
--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -310,6 +310,7 @@ class SubredditJsonTemplate(ThingJsonTemplate):
         user_is_moderator="is_moderator",
         user_is_subscriber="is_subscriber",
         user_sr_theme_enabled="user_sr_style_enabled",
+        quarantine="quarantine",
     )
 
     # subreddit *attributes* (right side of the equals)
@@ -387,6 +388,11 @@ class SubredditJsonTemplate(ThingJsonTemplate):
                 return c.user.use_subreddit_style(thing)
             else:
                 return True
+        elif attr == 'quarantine':
+            if thing.quarantine_enabled:
+                return thing.quarantine
+            else:
+                return None
         else:
             return ThingJsonTemplate.thing_attr(self, thing, attr)
 

--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -881,6 +881,12 @@ class CommentJsonTemplate(ThingTemplate):
             else:
                 link_url = item.link.url
             data["link_url"] = link_url
+            
+            if item.quarantine_enabled:
+                if item.subreddit.quarantine:
+                    data["quarantine"] = True
+                else:
+                    data["quarantine"] = False
 
         return data
 


### PR DESCRIPTION
This change adds a `quarantine` property to posts and comments when viewing them from a profile page (similar to how it works with the "quarantined" badge right now) and a `quarantine` property to a subreddit's info