### PR TITLE
Made it so users cannot friend themselves.

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -1037,6 +1037,10 @@ class ApiController(RedditController):
         # had better be the current user.
         if type == "friend" and container != c.user:
             abort(403,'forbidden')
+            
+        # users shouldn't be able to friend themselves.
+        if type == "friend" and c.user == friend:
+            abort(403, 'forbidden')
 
         elif form.has_errors("name", errors.USER_DOESNT_EXIST, errors.NO_USER):
             return


### PR DESCRIPTION
I noticed when I was using RES that I could make myself my own friend, meaning that the backend did no validation that the user was adding itself. I am my own friend, as shown below on my main account.

![Demonstration of Self-friend](http://i.imgur.com/8jBEkG5.png)

The way I can reproduce this is by using reddit enhancement suite, hovering over your name, and clicking the friend button. This would basically give a 403 if a request is even made for that.