### PR TITLE
Fix for "retry thumb" bug caused by bad cache data

### DIFF
--- a/r2/r2/lib/media.py
+++ b/r2/r2/lib/media.py
@@ -312,6 +312,16 @@ def _scrape_media(url, autoplay=False, maxwidth=600, force=False,
             print "%s made a bad secure media obj for url %s" % (scraper, url)
             secure_media_object = None
 
+        # If thumbnail can't be found, attempt again using _ThumbnailOnlyScraper
+        # This should fix bugs that occur when embed.ly caches links before the thumbnail is available
+        if not thumbnail_image:
+            scraper = _ThumbnailOnlyScraper(url)
+            try:
+                thumbnail_image, preview_object, _, _ = (
+                    scraper.scrape())
+            except (HTTPError, URLError) as e:
+                use_cache = False
+
         if thumbnail_image and save_thumbnail:
             thumbnail_size = thumbnail_image.size
             thumbnail_url = upload_media(thumbnail_image)
@@ -320,7 +330,9 @@ def _scrape_media(url, autoplay=False, maxwidth=600, force=False,
                       thumbnail_url, thumbnail_size)
 
     # Store the media in the cache (if requested), possibly extending the ttl
-    use_cache = use_cache and save_thumbnail    # don't cache partial scrape
+    
+    # don't cache partial scrape and don't cache if thumbnail is absent.
+    use_cache = use_cache and save_thumbnail and thumbnail_image 
     if use_cache and media is not ERROR_MEDIA:
         MediaByURL.add(url,
                        media,

--- a/r2/r2/lib/media.py
+++ b/r2/r2/lib/media.py
@@ -313,12 +313,12 @@ def _scrape_media(url, autoplay=False, maxwidth=600, force=False,
             secure_media_object = None
 
         # If thumbnail can't be found, attempt again using _ThumbnailOnlyScraper
-        # This should fix bugs that occur when embed.ly caches links before the thumbnail is available
-        if not thumbnail_image:
+        # This should fix bugs that occur when embed.ly caches links before the 
+        # thumbnail is available
+        if type(scraper) is _EmbedlyScraper and not thumbnail_image:
             scraper = _ThumbnailOnlyScraper(url)
             try:
-                thumbnail_image, preview_object, _, _ = (
-                    scraper.scrape())
+                thumbnail_image, preview_object, _, _ = (scraper.scrape())
             except (HTTPError, URLError) as e:
                 use_cache = False
 

--- a/r2/r2/lib/media.py
+++ b/r2/r2/lib/media.py
@@ -315,7 +315,7 @@ def _scrape_media(url, autoplay=False, maxwidth=600, force=False,
         # If thumbnail can't be found, attempt again using _ThumbnailOnlyScraper
         # This should fix bugs that occur when embed.ly caches links before the 
         # thumbnail is available
-        if type(scraper) is _EmbedlyScraper and not thumbnail_image:
+        if not thumbnail_image and not isinstance(scraper, _ThumbnailOnlyScraper):
             scraper = _ThumbnailOnlyScraper(url)
             try:
                 thumbnail_image, preview_object, _, _ = (scraper.scrape())


### PR DESCRIPTION
As seen here: https://www.reddit.com/r/redditdev/comments/3jaoe9/retry_thumb_appears_to_be_bugged/

Embed.ly would occationally cache data before the thumbnail was available for the page AND reddit's internal cache would also cache the meta data without the thumbnail, causing that link to appear without a thumbnail site wide. And when attempting to use the "retry thumb" function, it would simply look at the internally cached data without the thumb and return nothing again. 

So 2 problems were fixed here: 

1. If the media data does not contain a thumbnail, don't cache it internally, fixing the bug that causes the "retry thumb" to fail every time.
2. If thumbnail cannot be found from Embedly data, do a second attempt using the _ThumbnailOnlyScraper to bypass Embedly's cached data. 

This could have also been accomplished by passing a "forced=true" parameter to the EmbedlyScraper, but since it would have involved quite a few more changes, I though the simpler course of action would be to use the _ThumbnailOnlyScraper instead.