### PR TITLE
Prevent duplicate stickies

### DIFF
--- a/r2/r2/models/subreddit.py
+++ b/r2/r2/models/subreddit.py
@@ -1303,6 +1303,10 @@ class Subreddit(Thing, Printable, BaseSite):
             #   saved properly unless we assign a new list to the attr
             sticky_fullnames = self.sticky_fullnames[:]
 
+            # if the link is already stickied, remove it to prevent duplicates
+            if link._fullname in sticky_fullnames:
+                sticky_fullnames.remove(link._fullname)
+
             # if a particular slot was specified and is in use, replace it
             if num and num <= len(sticky_fullnames):
                 unstickied_fullnames.append(sticky_fullnames[num-1])


### PR DESCRIPTION
Previously a link was able to be stickied in both sticky slots simultaneously, resulting in a link being displayed twice in a subreddit's listing. This would have some interesting results, as seen in /r/ffxiv:

![](http://i.imgur.com/ofcUnoZ.png)