### PR TITLE
Fix vanishing data-fullname attribute from modmail messages.

### DIFF
--- a/r2/r2/templates/message.html
+++ b/r2/r2/templates/message.html
@@ -61,6 +61,7 @@
 </%def>
 
 <%def name="thing_data_attributes(what)">
+  ${parent.thing_data_attributes(what)}
   %if getattr(thing, "bar_color", "") and getattr(thing, "is_parent", False):
     style="border-color:${thing.bar_color}"
   %endif


### PR DESCRIPTION
The addition of subreddit colors introduced the `thing_data_attributes` def to the `message` template, which, according to my quick research about inheritance in mako, overrides the def of the same name in the parent `printable` template. This caused the `data-fullname` attribute to suddenly vanish and set many toolbox modmail features on fire.

As in the `thing_css_rowclass` def right above, the parent's `thing_data_attributes` should be executed to ensure data attributes like `data-fullname` are added.