### PR TITLE
Fix for incorrect 'config' permissions related to automoderator config

### DIFF
--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -501,19 +501,7 @@ class Reddit(Templated):
             if is_moderator_with_perms('flair'):
                 buttons.append(NamedButton("flair", css_class="reddit-flair"))
 
-        if is_single_subreddit and is_moderator_with_perms('wiki'):
-            # append automod button if they have an AutoMod configuration
-            try:
-                WikiPage.get(c.site, "config/automoderator")
-                buttons.append(NamedButton(
-                    "automod",
-                    dest="../wiki/config/automoderator",
-                    css_class="reddit-automod",
-                ))
-            except tdb_cassandra.NotFound:
-                pass
-
-        if is_single_subreddit and is_moderator_with_perms('config'):
+        if is_single_subreddit and is_moderator_with_perms('wiki') or is_moderator_with_perms('config'):
             # append automod button if they have an AutoMod configuration
             try:
                 WikiPage.get(c.site, "config/automoderator")

--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -501,6 +501,18 @@ class Reddit(Templated):
             if is_moderator_with_perms('flair'):
                 buttons.append(NamedButton("flair", css_class="reddit-flair"))
 
+        if is_single_subreddit and is_moderator_with_perms('wiki'):
+            # append automod button if they have an AutoMod configuration
+            try:
+                WikiPage.get(c.site, "config/automoderator")
+                buttons.append(NamedButton(
+                    "automod",
+                    dest="../wiki/config/automoderator",
+                    css_class="reddit-automod",
+                ))
+            except tdb_cassandra.NotFound:
+                pass
+
         if is_single_subreddit and is_moderator_with_perms('config'):
             # append automod button if they have an AutoMod configuration
             try:

--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -501,13 +501,25 @@ class Reddit(Templated):
             if is_moderator_with_perms('flair'):
                 buttons.append(NamedButton("flair", css_class="reddit-flair"))
 
-        if is_single_subreddit and is_moderator_with_perms('wiki') or is_moderator_with_perms('config'):
-            # append automod button if they have an AutoMod configuration
+        if is_single_subreddit and is_moderator_with_perms('wiki'):
+            # append automod button if they have an AutoMod configuration for 'wiki' perms
             try:
                 WikiPage.get(c.site, "config/automoderator")
                 buttons.append(NamedButton(
                     "automod",
                     dest="../wiki/config/automoderator",
+                    css_class="reddit-automod",
+                ))
+            except tdb_cassandra.NotFound:
+                pass
+
+        if is_single_subreddit and is_moderator_with_perms('config'):
+            # append automod button if they have an AutoMod configuration for 'config' perms
+            try:
+                WikiPage.get(c.site, "config/automoderator")
+                buttons.append(NamedButton(
+                    "automod",
+                    dest="../wiki/edit/config/automoderator",
                     css_class="reddit-automod",
                 ))
             except tdb_cassandra.NotFound:

--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -501,7 +501,7 @@ class Reddit(Templated):
             if is_moderator_with_perms('flair'):
                 buttons.append(NamedButton("flair", css_class="reddit-flair"))
 
-        if is_single_subreddit and is_moderator_with_perms('wiki'):
+        if is_single_subreddit and is_moderator_with_perms('config'):
             # append automod button if they have an AutoMod configuration
             try:
                 WikiPage.get(c.site, "config/automoderator")

--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -501,7 +501,7 @@ class Reddit(Templated):
             if is_moderator_with_perms('flair'):
                 buttons.append(NamedButton("flair", css_class="reddit-flair"))
 
-        if is_single_subreddit and is_moderator_with_perms('wiki'):
+        if is_single_subreddit and is_moderator_with_perms('wiki') and not is_moderator_with_perms(‘config’):
             # append automod button if they have an AutoMod configuration for 'wiki' perms
             try:
                 WikiPage.get(c.site, "config/automoderator")

--- a/r2/r2/lib/validator/wiki.py
+++ b/r2/r2/lib/validator/wiki.py
@@ -55,11 +55,7 @@ def this_may_view(page):
     if user and c.user_is_admin:
         return True
     return may_view(c.site, user, page)
-    
-    if sr.is_moderator_with_perms(user, 'wiki'):
-        # Mods with 'wiki' permissions may view config
-        return True
-
+ 
 def may_revise(sr, user, page=None):    
     if sr.is_moderator_with_perms(user, 'wiki'):
         # Mods may always contribute to non-config pages

--- a/r2/r2/lib/validator/wiki.py
+++ b/r2/r2/lib/validator/wiki.py
@@ -55,6 +55,10 @@ def this_may_view(page):
     if user and c.user_is_admin:
         return True
     return may_view(c.site, user, page)
+    
+    if sr.is_moderator_with_perms(user, 'wiki'):
+        # Mods with 'wiki' permissions may view config
+        return True
 
 def may_revise(sr, user, page=None):    
     if sr.is_moderator_with_perms(user, 'wiki'):


### PR DESCRIPTION
Resolves #1402 by granting mods with 'config' permissions the ability to see "automod config" in the moderation tools sidebar and link to the editor. A more robust solution than #1403 as it retains 'wiki' mods access to that button and instead links them to a viewable page.