### PR TITLE
Fix for incorrect 'config' permissions related to automoderator config 

### DIFF
--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -501,8 +501,20 @@ class Reddit(Templated):
             if is_moderator_with_perms('flair'):
                 buttons.append(NamedButton("flair", css_class="reddit-flair"))
 
-        if is_single_subreddit and is_moderator_with_perms('wiki'):
-            # append automod button if they have an AutoMod configuration
+        if is_single_subreddit and is_moderator_with_perms('wiki') and not is_moderator_with_perms(‘config’):
+            # append automod button if they have an AutoMod configuration for 'wiki' perms
+            try:
+                WikiPage.get(c.site, "config/automoderator")
+                buttons.append(NamedButton(
+                    "automod",
+                    dest="../wiki/config/automoderator",
+                    css_class="reddit-automod",
+                ))
+            except tdb_cassandra.NotFound:
+                pass
+
+        if is_single_subreddit and is_moderator_with_perms('config'):
+            # append automod button if they have an AutoMod configuration for 'config' perms
             try:
                 WikiPage.get(c.site, "config/automoderator")
                 buttons.append(NamedButton(


### PR DESCRIPTION
Grants mods with 'config' permissions the ability to see "automoderator config" in the moderation tools sidebar and link to the editor. Previously this button only showed for 'wiki' mods which did not match with prior documentation that allows this action for 'config' mods. Furthermore this resolves #1402 by linking wiki mods to the viewable URL instead of the edit one to which they do not have permission.

A more robust solution than #1403 as it seamlessly retains 'wiki' mods access to that "automoderator config" button and instead links them to a viewable page instead of just simply giving the access to 'config' mods and leaving 'wiki' mods with a shortcut.