### PR TITLE
Correct md_sender in "gold gift" messages.

### DIFF
--- a/r2/r2/controllers/ipn.py
+++ b/r2/r2/controllers/ipn.py
@@ -279,7 +279,7 @@ def send_gift(buyer, recipient, months, days, signed, giftmessage,
 
     if signed:
         sender = buyer.name
-        md_sender = "[%s](/user/%s)" % (sender, sender)
+        md_sender = "/u/%s" % (sender)
         repliable = True
     else:
         sender = _("An anonymous redditor")


### PR DESCRIPTION
Previously, due to how Snudown works, if a username had two underscores, it would be rendered as if anything within the underlines would be italicized, and the underlines dropped. This makes it so that the italicizing effect caused by underlines no longer makes this render incorrectly; at the minimal cost of making the sender's name in `/u/` format, (which in reality, affects absolutely nothing in terms of meaning of the message/sender)

[BUG REPORT](https://www.reddit.com/r/bugs/comments/3krzm8/username_is_displayed_incorrectly_in_guild/)