### PR TITLE
Doesn't use cache metadata if thumbnail missing

### DIFF
--- a/r2/r2/lib/media.py
+++ b/r2/r2/lib/media.py
@@ -284,8 +284,8 @@ def _scrape_media(url, autoplay=False, maxwidth=600, force=False,
         if mediaByURL:
             media = mediaByURL.media
 
-    # Otherwise, scrape it
-    if not media:
+    # Otherwise, scrape it if thumbnail is present
+    if not media or not media.thumbnail_url or not media.thumbnail_size:
         media_object = secure_media_object = None
         thumbnail_image = thumbnail_url = thumbnail_size = None
 


### PR DESCRIPTION
Still instances where data is being cached with invalid thumbnail. Couldn't pinpoint where it might be getting through, so added additional checks when grabbing the cached data to ensure it's valid. 

I could also do this in the '/r2/r2/models/media_cache.py' file, I believe, but didn't know if that would be better.