### PR TITLE
Change so mods can't block their own subreddits

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -1709,7 +1709,9 @@ class ApiController(RedditController):
             sr = None
 
         if getattr(thing, "from_sr", False) and sr:
-            BlockedSubredditsByAccount.block(c.user, sr)
+            # Users may only block a subreddit they don't mod
+            if not (sr.is_moderator(c.user) or c.user_is_admin):
+                BlockedSubredditsByAccount.block(c.user, sr)
             return
 
         # Users may only block someone who has

--- a/r2/r2/templates/printablebuttons.html
+++ b/r2/r2/templates/printablebuttons.html
@@ -453,17 +453,21 @@
     %if thing.can_block:
       ${self.banbuttons()}
         %if (not thing.was_comment or thing.thing.is_mention) and thing.thing.author_id != c.user._id and thing.thing.author_id not in c.user.enemies:
-          <li>
-            %if getattr(thing.thing, "from_sr", False):
-              %if getattr(thing.thing, "sr_blocked", False):
-                ${ynbutton(_("unblock subreddit"), _("unblocked"), "unblock_subreddit")}
-              %else:
-                ${ynbutton(_("block subreddit"), _("blocked"), "block", "hide_thing")}
-              %endif
-            %else:
-              ${ynbutton(_("block user"), _("blocked"), "block", "hide_thing")}
+          %if getattr(thing.thing, "from_sr", False):
+            %if not (thing.thing.user_is_moderator or c.user_is_admin):
+              <li>
+                %if getattr(thing.thing, "sr_blocked", False):
+                  ${ynbutton(_("unblock subreddit"), _("unblocked"), "unblock_subreddit")}
+                %else:
+                  ${ynbutton(_("block subreddit"), _("blocked"), "block", "hide_thing")}
+                %endif
+              </li>
             %endif
-          </li>
+          %else:
+            <li>
+              ${ynbutton(_("block user"), _("blocked"), "block", "hide_thing")}
+            </li>
+          %endif
           %if thing.can_mute:
             <li>
               %if getattr(thing.thing, "sr_muted", False):


### PR DESCRIPTION
Previously, a mod would be able to block their own subreddit in their modmail, if they saw a ban message / original mod invite message.

This changes it so the block subreddit buttons would only show the block subreddit button if the user is not a mod of the subreddit.