### PR TITLE
Add an API endpoint to get the subreddits moderated by a user.

### DIFF
--- a/r2/r2/config/routing.py
+++ b/r2/r2/config/routing.py
@@ -143,6 +143,7 @@ def make_map(config):
     mc('/user/:username/about', controller='user', action='about',
        where='overview')
     mc('/user/:username/trophies', controller='user', action='trophies')
+    mc('/user/:username/moderated', controller='user', action='moderated_srs')
     mc('/user/:username/:where', controller='user', action='listing',
        where='overview')
     mc('/user/:username/saved/:category', controller='user', action='listing',


### PR DESCRIPTION
This has [been](https://www.reddit.com/r/redditdev/comments/35v5h5/is_there_an_api_call_for_getting_list_of_a_users/) [requested](https://www.reddit.com/r/redditdev/comments/2c64ed/praw_can_i_get_the_list_of_subrredits_moderated/) [several](https://www.reddit.com/r/redditdev/comments/3gae4j/how_can_i_get_a_list_of_subreddits_a_user/?) [times](https://www.reddit.com/r/redditdev/comments/3jx0ik/request_can_we_get_an_endpoint_for_a_users_mod) in /r/redditdev.  It adds an endpoint at `/user/<username>/moderated`.