### PR TITLE
Add CSS class indicating deleted vs removed status

### DIFF
--- a/r2/r2/models/link.py
+++ b/r2/r2/models/link.py
@@ -1436,8 +1436,10 @@ class Comment(Thing, Printable):
                     # If removed by an admin or moderator, distinguish that
                     # from being deleted by the user.
                     if item._spam:
+                        extra_css += " removed"
                         item.body = '[removed]'
                     else:
+                        extra_css += " deleted"
                         item.body = '[deleted]'
 
             if focal_comment == item._id36:


### PR DESCRIPTION
This allows CSS to differentiate between posts that are deleted by the user, and posts that are removed by a moderator or administrator