### PR TITLE
Add meta tag for AlienBlue in iOS

### DIFF
--- a/r2/r2/templates/base.html
+++ b/r2/r2/templates/base.html
@@ -34,6 +34,7 @@
     <meta name="keywords" content="${self.keywords()}" />
     <meta name="description" content="${getattr(thing, 'short_description', None) or g.short_description}" />
     <meta name="referrer" content="${c.referrer_policy}">
+    <meta name="apple-itunes-app" content="app-id=923187241">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     %if hasattr(thing, 'mobile_link'):
         <link rel="alternate" media="only screen and (max-width: 640px)" href="${thing.mobile_link}" />

--- a/r2/r2/templates/base.html
+++ b/r2/r2/templates/base.html
@@ -34,7 +34,7 @@
     <meta name="keywords" content="${self.keywords()}" />
     <meta name="description" content="${getattr(thing, 'short_description', None) or g.short_description}" />
     <meta name="referrer" content="${c.referrer_policy}">
-    <meta name="apple-itunes-app" content="app-id=923187241">
+    <meta name="apple-itunes-app" content="app-id=923187241" app-argument="${request.url}">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     %if hasattr(thing, 'mobile_link'):
         <link rel="alternate" media="only screen and (max-width: 640px)" href="${thing.mobile_link}" />

--- a/r2/r2/templates/base.mobile
+++ b/r2/r2/templates/base.mobile
@@ -29,7 +29,7 @@
 <head>
 
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<meta name="apple-itunes-app" content="app-id=923187241">
+<meta name="apple-itunes-app" content="app-id=923187241" app-argument="${request.url}">
 <meta name="referrer" content="${c.referrer_policy}" />
 <link rel="canonical" href="${thing.canonical_link}" />
 

--- a/r2/r2/templates/base.mobile
+++ b/r2/r2/templates/base.mobile
@@ -29,6 +29,7 @@
 <head>
 
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<meta name="apple-itunes-app" content="app-id=923187241">
 <meta name="referrer" content="${c.referrer_policy}" />
 <link rel="canonical" href="${thing.canonical_link}" />
 


### PR DESCRIPTION
As per issue #1240, add a meta tag to support promotion of AlienBlue via Smart App Banners for iOS.