### PR TITLE
Don't make things with NSFW in the title forced

### DIFF
--- a/r2/r2/models/link.py
+++ b/r2/r2/models/link.py
@@ -217,10 +217,8 @@ class Link(Thing, Printable):
             url = content
             selftext = cls._defaults["selftext"]
 
-        nsfwcheck = re.compile(r"\bnsf[wl]\b", re.I)
         over_18 = False
-
-        if bool(nsfwcheck.search(title)):
+        if cls._nsfw.search(title):
             over_18 = True
 
         l = cls(
@@ -236,7 +234,7 @@ class Link(Thing, Printable):
             ip=ip,
             comment_tree_version=cls._choose_comment_tree_version(),
             is_self=is_self,
-            over_18=over_18
+            over_18=over_18,
         )
 
         l._commit()

--- a/r2/r2/models/link.py
+++ b/r2/r2/models/link.py
@@ -217,6 +217,12 @@ class Link(Thing, Printable):
             url = content
             selftext = cls._defaults["selftext"]
 
+        nsfwcheck = re.compile(r"\bnsf[wl]\b", re.I)
+        over_18 = False
+
+        if bool(nsfwcheck.search(title)):
+            over_18 = True
+
         l = cls(
             _ups=1,
             title=title,
@@ -230,6 +236,7 @@ class Link(Thing, Printable):
             ip=ip,
             comment_tree_version=cls._choose_comment_tree_version(),
             is_self=is_self,
+            over_18=over_18
         )
 
         l._commit()


### PR DESCRIPTION
Resolves [this](https://www.reddit.com/r/ModSupport/comments/3n46i3/request_allow_mods_to_unnsfw_posts_regardless_of/). This allows for posts that have nsfw in the title to determine the over_18 attribute, *once*, at creation, instead of forcing posts to be nsfw via the over_18 attribute "or" the fact that it has the phrase "nsfw" in some form. Because of the fact that it only does this at creation, the over_18 attribute can be changed successfully, and the previous or statement takes no effect (and as such is removed).


Edit: Just realized the logic is ever so slightly off, so don't merge yet. As it is, any currently made nsfw post that doesn't have nsfw in the title may be auto unnsfwd, due to me adding the dummy check and that check is added, and then when the check needs to run the first time it will determine over_18 only based on the property. A check for `if not self.over_18` before setting over_18 should correct it though, or you can do some server side magic to get all current nsfw submissions and set their over_18 value to True after implementing.