### PR TITLE
Force successor permissions

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -699,6 +699,9 @@ class ApiController(RedditController):
 
         """
         if container and container.is_contributor(c.user):
+            if container.is_moderator_with_perms(c.user, 'access'):
+                ModAction.create(container, c.user, 'removecontributor',
+                                 target=c.user, details='remove_self')
             container.remove_contributor(c.user)
 
 

--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -850,7 +850,9 @@ class ApiController(RedditController):
 
         # Log this action
         if new and type in self._sr_friend_types:
-            ModAction.create(container, c.user, action, target=victim)
+            details = (c.user == victim and 'remove_self') or None
+            ModAction.create(container, c.user, action, target=victim,
+                             details=details)
 
         if type == "friend" and c.user.gold:
             c.user.friend_rels_cache(_update=True)

--- a/r2/r2/models/subreddit.py
+++ b/r2/r2/models/subreddit.py
@@ -568,7 +568,7 @@ class Subreddit(Thing, Printable, BaseSite):
         hook = hooks.get_hook("subreddit.remove_moderator")
         hook.call(subreddit=self, user=user)
 
-        top_mod_id = self.moderators[0]
+        top_mod_id = self.moderators[0] if self.moderators else None
 
         ret = super(Subreddit, self).remove_moderator(user, **kwargs)
 


### PR DESCRIPTION
When a top mod removes him/herself, there was no insurance to the fact that the next mod should recieve full permissions. This commit makes a common /r/redditrequest automated and should reduce strain on that subreddit. This also automates the removal of spam/deleted users if they would be the successor.

I've made the two properties in subreddit.py just because there are other semi-issues that rely on what would be provided by those properties, so for the sake of making it easier on future issues I was going to fix, I made them properties instead of determining them in api.py
