### PR TITLE
Resolve issues with contest mode upvote only subs

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -2199,6 +2199,11 @@ class ApiController(RedditController):
         if thing._age > thing.subreddit_slow.archive_age:
             store = False
 
+        if (dir < 0 and isinstance(thing, Comment):
+            if (thing.link_slow.contest_mode and
+                thing.subreddit_slow.contest_mode_upvotes_only):
+                store = False
+
         dir = (True if dir > 0
                else False if dir < 0
                else None)

--- a/r2/r2/lib/strings.py
+++ b/r2/r2/lib/strings.py
@@ -144,6 +144,7 @@ string_dict = dict(
     gold_summary_gilding_page_link = _("You're about to give *%(recipient)s* a month of [reddit gold](/gold/about) for this submission:"),
     gold_summary_gilding_page_footer = _("You'll pay a total of %(price)s for this."),
     unvotable_message = _("sorry, this has been archived and can no longer be voted on"),
+    contest_mode_no_downvote = _("sorry, this subreddit has downvotes disabled when contest mode is on"),
     archived_post_message = _("This is an archived post. You won't be able to vote or comment."),
     locked_post_message = _("This post is locked. You won't be able to comment."),
     account_activity_blurb = _("This page shows a history of recent activity on your account. If you notice unusual activity, you should change your password immediately. Location information is guessed from your computer's IP address and may be wildly wrong, especially for visits from mobile devices."),

--- a/r2/r2/models/link.py
+++ b/r2/r2/models/link.py
@@ -1611,14 +1611,9 @@ class Comment(Thing, Printable):
                 item.render_css_class += " score-hidden"
 
             # in contest mode, use only upvotes for the score if the subreddit
-            # has been (manually) set to do so
-            if (item.link.contest_mode and
-                    item.subreddit.contest_mode_upvotes_only and
-                    not item.score_hidden):
-                item.score = item._ups
-                item.voting_score = [
-                    item.score - 1, item.score, item.score + 1]
-                item.collapsed = False
+            # has been (manually) set to do so. This is a convenience attribute
+            if (item.link.contest_mode and item.subreddit.contest_mode_upvotes_only):
+                item.cannot_downvote = True
 
             if item.is_author:
                 item.inbox_replies_enabled = item.sendreplies

--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -3830,7 +3830,8 @@ label + #moresearchinfo {
     font-style: italic;
 }
 
-.unvotable-message {
+.unvotable-message,
+.nodownvote-message {
     border: solid 1px #ff6600;
     margin-top: 4px;
     padding: 1px 3px;

--- a/r2/r2/public/static/js/jquery.reddit.js
+++ b/r2/r2/public/static/js/jquery.reddit.js
@@ -318,6 +318,10 @@ $.fn.show_unvotable_message = function() {
   $(this).thing().find(".entry:first .unvotable-message").css("display", "inline-block");
 };
 
+$.fn.show_nodownvote_message = function() {
+  $(this).thing().find(".entry:first .nodownvote-message").css("display", "inline-block");
+};
+
 $.fn.thing = function() {
     /* Returns the first thing that is a parent of the current element */
     return this.parents(".thing:first");

--- a/r2/r2/public/static/js/voting.js
+++ b/r2/r2/public/static/js/voting.js
@@ -45,6 +45,11 @@
         return;
       }
 
+      if ($el.hasClass('nodownvotes')) {
+        $el.show_nodownvote_message();
+        return;
+      }
+
       var $thing = $el.thing();
       var id = $thing.thing_id();
       var dir = $el.hasClass(UP_CLS) ? 1 : $el.hasClass(DOWN_CLS) ? -1 : 0;

--- a/r2/r2/templates/comment_skeleton.html
+++ b/r2/r2/templates/comment_skeleton.html
@@ -54,6 +54,9 @@
   %if not getattr(thing, "votable", True):
     <div class="unvotable-message">${strings.unvotable_message}</div>
   %endif
+  %if getattr(thing, "cannot_downvote", False):
+    <div class="nodownvote-message">${strings.contest_mode_no_downvote}</div>
+  %endif
 </p>
 
 ${self.commentBody()}

--- a/r2/r2/templates/linkcommentssettings.html
+++ b/r2/r2/templates/linkcommentssettings.html
@@ -129,5 +129,8 @@
   %else:
     ${_('contest mode randomizes comment sorting, hides scores, and collapses replies by default.')}
   %endif
+  %if thing.sr.contest_mode_upvotes_only:
+    ${_('Downvoting is disabled for threads on contest mode in this subreddit.')}
+  %endif
   </div>
 %endif

--- a/r2/r2/templates/printable.html
+++ b/r2/r2/templates/printable.html
@@ -215,8 +215,9 @@ ${self.RenderPrintable()}
    arrow_class = arrow_type + ("mod" if mod else "")
    login_class = "login-required" if not g.read_only_mode else ""
    archived_class = "archived" if not getattr(thing, 'votable', True) else ""
+   nodownvotes_class = "nodownvotes" if getattr(thing, 'cannot_downvote', False) and dir <=0 else ""
 %>
-  <div ${classes("arrow", arrow_class, login_class, archived_class)}
+  <div ${classes("arrow", arrow_class, login_class, archived_class, nodownvotes_class)}
     %if not g.read_only_mode:
        role="button"
        % if dir > 0:


### PR DESCRIPTION
Resolves the issues underlined in [this post](https://www.reddit.com/r/ModSupport/comments/3n9676/contest_mode_could_really_use_a_few_minor_ui/).

* This makes it so that the first issue no longer exists, as the score isn't being altered server side, but rather downvotes are blocked.

* This resolves the second issue in the same way.

* This resolves the third issue by making it so that a message similar to that which happens on an archived post's comments when voting on them (but of course, only for downvotes).

* This also resolves an issue noone knew about (as far as I can tell); that the comments could never be properly collapsed.

Brought to my attention by @1point618

Edit:

This adds:

* A message on the contest mode notification itself