### PR TITLE
Fix inconsistency in post json

### DIFF
--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -685,7 +685,7 @@ class LinkJsonTemplate(ThingJsonTemplate):
             if not thing.expunged:
                 return thing.selftext
             else:
-                return ''
+                return '[removed]'
         elif attr == 'selftext_html':
             if not thing.expunged:
                 return safemarkdown(thing.selftext)


### PR DESCRIPTION
While post's selftext now shows differences between '[removed]' and '[deleted]', as well as in comments, this opened a new inconsistency with the json response of posts, which is when a post is removed the selftext key is `''` instead of `[removed]`.

This commit resolves this inconsistency.