### PR TITLE
Add "NO_USER" error to UserListing view

### DIFF
--- a/r2/r2/templates/userlisting.html
+++ b/r2/r2/templates/userlisting.html
@@ -74,6 +74,7 @@
     %endif
     <button class="btn" type="submit">${verb or _("add")}</button>
     <span class="status"></span>
+    ${error_field("NO_USER", "name")}
     ${error_field("USER_DOESNT_EXIST", "name")}
     ${error_field("ALREADY_MODERATOR", "name")}
     ${error_field("CANT_RESTRICT_MODERATOR", "name")}


### PR DESCRIPTION
Otherwise this looks like it successfully banned the user, but nothing changes on the page.

Reproduce by going to /about/banned, leave "name" blank, and hit "add"