### PR TITLE
Add a "bottom" and "worst" comments sort for moderators

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -2566,7 +2566,7 @@ class ApiController(RedditController):
                    css_on_cname = VBoolean("css_on_cname"),
                    hide_ads = VBoolean("hide_ads"),
                    suggested_comment_sort=VOneOf('suggested_comment_sort',
-                                                 CommentSortMenu._options,
+                                                 CommentSortMenu.sub_suggested_sort_options,
                                                  default=None),
                    # community_rules = VLength('community_rules', max_length=1024),
                    # related_subreddits = VSubredditList('related_subreddits', limit=20),

--- a/r2/r2/controllers/front.py
+++ b/r2/r2/controllers/front.py
@@ -355,6 +355,9 @@ class FrontController(RedditController):
         if comment:
             displayPane.append(PermalinkMessage(article.make_permalink_slow()))
             page_classes.append('comment-permalink-page')
+        # if the user is a mod, add a class to visually allow switching to mod sorts
+        if c.user_is_loggedin and sr.is_moderator_with_perms(c.user, 'posts'):
+            page_classes.append('modsorts-on')
 
         displayPane.append(LinkCommentSep())
 
@@ -406,6 +409,22 @@ class FrontController(RedditController):
         elif suggested_sort and 'sort' not in request.params:
             sort = suggested_sort
             suggested_sort_active = True
+
+        # only mods with the posts perm use mod sorts
+        if sort in CommentSortMenu.mod_options:
+            if c.user_is_loggedin:
+                if not sr.is_moderator_with_perms(c.user, 'posts'):
+                    if suggested_sort and 'sort' not in request.params:
+                        sort = suggested_sort
+                        suggested_sort_active = True
+                    else:
+                        sort = c.user.pref_default_comment_sort
+            else:
+                if suggested_sort and 'sort' not in request.params:
+                    sort = suggested_sort
+                    suggested_sort_active = True
+                else:
+                    sort = c.user.pref_default_comment_sort
 
         # finally add the comment listing
         displayPane.append(CommentPane(article, CommentSortMenu.operator(sort),

--- a/r2/r2/lib/menus.py
+++ b/r2/r2/lib/menus.py
@@ -521,6 +521,7 @@ class PageNameNav(Styled):
 class SortMenu(NavMenu):
     name = 'sort'
     hidden_options = []
+    mod_options = []
     button_cls = QueryButton
 
     # these are _ prefixed to avoid colliding with NavMenu attributes
@@ -542,7 +543,15 @@ class SortMenu(NavMenu):
     def make_buttons(self):
         buttons = []
         for name in self._options:
-            css_class = 'hidden' if name in self.hidden_options else ''
+            classes = []
+            if name in self.hidden_options:
+                classes.append('hidden')
+            if name in self.mod_options:
+                classes.append('modsort')
+            if classes == []:
+                css_class = ''
+            else:
+                css_class = ' '.join(classes)
             button = self.button_cls(self.make_title(name), name, self.name,
                                      css_class=css_class)
             buttons.append(button)
@@ -584,24 +593,33 @@ class CommentSortMenu(SortMenu):
     _default = 'confidence'
     _options = ('confidence', 'top', 'new', 'hot', 'controversial', 'old',
                  'random', 'qa', 'bottom', 'worst',)
-
     # Links may have a suggested sort of 'blank', which is an explicit None -
     # that is, do not check the subreddit for a suggested sort, either.
-    suggested_sort_options = _options + ('blank',)
+    sub_suggested_sort_options = ('confidence', 'top', 'new', 'hot', 'controversial',
+                                  'old', 'random', 'qa',)
+    suggested_sort_options = sub_suggested_sort_options + ('blank',)
 
     def __init__(self, *args, **kwargs):
         self.suggested_sort = kwargs.pop('suggested_sort', None)
         super(CommentSortMenu, self).__init__(*args, **kwargs)
 
     @classmethod
-    def visible_options(cls):
-        return set(cls._options) - set(cls.hidden_options)
+    def visible_options(cls, is_article=False):
+        options =  set(cls._options) - set(cls.hidden_options)
+        if not is_article:
+            options -= set(cls.mod_options)
+        return options
 
     @class_property
     def hidden_options(cls):
         sorts = ['random']
         if feature.is_enabled('remove_hot_comments'):
             sorts.append('hot')
+        return sorts
+
+    @class_property
+    def mod_options(cls):
+        sorts = ['bottom', 'worst']
         return sorts
 
     def make_title(self, attr):

--- a/r2/r2/lib/menus.py
+++ b/r2/r2/lib/menus.py
@@ -59,6 +59,8 @@ menu =   MenuHandler(hot          = _('hot'),
                      confidence   = _('best'),
                      random       = _('random'),
                      qa           = _('q&a'),
+                     bottom       = _('bottom'),
+                     worst        = _('worst'),
                      saved        = _('saved {toolbar}'),
                      recommended  = _('recommended'),
                      rising       = _('rising'), 
@@ -558,6 +560,8 @@ class SortMenu(NavMenu):
         "confidence": operators.desc('_confidence'),
         "random": operators.shuffled('_confidence'),
         "qa": operators.desc('_qa'),
+        "bottom": operators.asc('_score'),
+        "worst": operators.asc('_confidence'),
     }
     _reverse_mapping = {v: k for k, v in _mapping.iteritems()}
 
@@ -579,7 +583,7 @@ class CommentSortMenu(SortMenu):
     """Sort menu for comments pages"""
     _default = 'confidence'
     _options = ('confidence', 'top', 'new', 'hot', 'controversial', 'old',
-                 'random', 'qa',)
+                 'random', 'qa', 'bottom', 'worst',)
 
     # Links may have a suggested sort of 'blank', which is an explicit None -
     # that is, do not check the subreddit for a suggested sort, either.

--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -448,8 +448,12 @@ ul.flat-vert {text-align: left;}
 .drop-choices.tabdrop {margin-top: 2px;}
 .dropdown-title.tabdrop { display: none }
 
-.drop-choices .choice.hidden {
+.drop-choices .choice.hidden,
+.drop-choices .choice.modsort {
     display: none;
+}
+.modsorts-on .drop-choices .choice.modsort {
+    display: block;
 }
 
 .tabmenu {

--- a/r2/r2/templates/linkcommentssettings.html
+++ b/r2/r2/templates/linkcommentssettings.html
@@ -23,6 +23,7 @@
 <%!
   from r2.config import feature
   from r2.lib.filters import jssafe
+  from r2.lib.menus import CommentSortMenu
 %>
 
 <%namespace file="printablebuttons.html" import="ynbutton" />
@@ -78,11 +79,13 @@
 </%def>
 
 %if thing.can_edit:
-  %if thing.suggested_sort == thing.sort:
-    <% clear_suggested_sort() %>
-  %else:
-    ${ynbutton(_("set as suggested sort"), _("suggested sort set"), "set_suggested_sort",
-      hidden_data=dict(id=thing.link._fullname, sort=thing.sort))}
+  %if thing.sort not in CommentSortMenu.mod_options:
+    %if thing.suggested_sort == thing.sort:
+      <% clear_suggested_sort() %>
+    %else:
+      ${ynbutton(_("set as suggested sort"), _("suggested sort set"), "set_suggested_sort",
+        hidden_data=dict(id=thing.link._fullname, sort=thing.sort))}
+    %endif
   %endif
 %endif
 


### PR DESCRIPTION
Adds both sorts for comments for mods with the "posts" perm only, as asked several times for on /r/ideasfortheadmins and /r/modsupport. If this is wanted, you may want b751b5f of #1440 to be changed slightly so that mods could sort the comments there as well. 

One thing that I'm having trouble deciding on is if comments should be forced to be uncollapsed on these sorts, so for not I didn't make un-collapsement forced but if you want, I added it in the third commit.

E: I added the third commit