### PR TITLE
Fix Incorecct Name Scheme in TimeMenu

### DIFF
--- a/r2/r2/controllers/listingcontroller.py
+++ b/r2/r2/controllers/listingcontroller.py
@@ -33,8 +33,8 @@ from r2.lib.filters import _force_unicode
 from r2.lib.jsontemplates import get_usertrophies
 from r2.lib.pages import *
 from r2.lib.pages.things import wrap_links
-from r2.lib.menus import TimeMenu, SortMenu, RecSortMenu, ProfileSortMenu
-from r2.lib.menus import ControversyTimeMenu, menu, QueryButton
+from r2.lib.menus import TimeMenu, CommentsTimeMenu, SortMenu, RecSortMenu, ProfileSortMenu
+from r2.lib.menus import ControversyTimeMenu, ProfileOverviewTimeMenu, menu, QueryButton
 from r2.lib.rising import get_rising, normalized_rising
 from r2.lib.wrapped import Wrapped
 from r2.lib.normalized_hot import normalized_hot
@@ -707,7 +707,12 @@ class UserController(ListingController):
         if (self.where in ('overview', 'submitted', 'comments')):
             res.append(ProfileSortMenu(default = self.sort))
             if self.sort not in ("hot", "new"):
-                res.append(TimeMenu(default = self.time))
+                if self.where == "comments":
+                    res.append(CommentsTimeMenu(default = self.time))
+                elif self.where == "overview":
+                    res.append(ProfileOverviewTimeMenu(default = self.time))
+                else:
+                    res.append(TimeMenu(default = self.time))
         if self.where == 'saved' and c.user.gold:
             srnames = LinkSavesBySubreddit.get_saved_subreddits(self.vuser)
             srnames += CommentSavesBySubreddit.get_saved_subreddits(self.vuser)

--- a/r2/r2/lib/menus.py
+++ b/r2/r2/lib/menus.py
@@ -662,6 +662,15 @@ class TimeMenu(SortMenu):
         if time != 'all':
             return Link.c._date >= timeago(time)
 
+class CommentsTimeMenu(TimeMenu):
+    """Time Menu with the title changed for comments"""
+    _title = N_("comments from")
+
+
+class ProfileOverviewTimeMenu(TimeMenu):
+    """Time Menu with the title changed for a user overview"""
+    _title = N_("links and comments from")
+
 
 class ControversyTimeMenu(TimeMenu):
     """time interval for controversial sort.  Make default time 'day' rather than 'all'"""


### PR DESCRIPTION
Fixes an incorrect naming scheme in the timemenu, as the User overview and user /comments section have an incorrect name in the time menu ("links from"), when it should be either "things from" or "comments from"

If this and #1440 is excepted, you may want me to fix this (spelling?) error there as well, as I didn't make the change there.