### PR TITLE
Clarify [removed] and [deleted].

### DIFF
--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -690,7 +690,7 @@ class LinkJsonTemplate(ThingJsonTemplate):
             if not thing.expunged:
                 return safemarkdown(thing.selftext)
             else:
-                return safemarkdown(_("[removed]"))
+                return safemarkdown(_("[removed by moderator]"))
         elif attr == "archived":
             return not thing.votable
         return ThingJsonTemplate.thing_attr(self, thing, attr)

--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -685,7 +685,7 @@ class LinkJsonTemplate(ThingJsonTemplate):
             if not thing.expunged:
                 return thing.selftext
             else:
-                return ''
+                return '[removed by moderator]'
         elif attr == 'selftext_html':
             if not thing.expunged:
                 return safemarkdown(thing.selftext)

--- a/r2/r2/models/link.py
+++ b/r2/r2/models/link.py
@@ -1478,9 +1478,9 @@ class Comment(Thing, Printable):
                     # If removed by an admin or moderator, distinguish that
                     # from being deleted by the user.
                     if item._spam:
-                        item.body = '[removed]'
+                        item.body = '[removed by moderator]'
                     else:
-                        item.body = '[deleted]'
+                        item.body = '[deleted by author]'
 
             if focal_comment == item._id36:
                 extra_css += " border"

--- a/r2/r2/models/link.py
+++ b/r2/r2/models/link.py
@@ -761,7 +761,10 @@ class Link(Thing, Printable):
             if item.deleted and not c.user_is_admin:
                 item.author = DeletedUser()
                 item.as_deleted = True
-                item.selftext = '[deleted]'
+                if item._spam:
+                    item.selftext = '[removed by moderator]'
+                else:
+                    item.selftext = '[deleted by user]'
 
             item.votable = not item.archived
 

--- a/r2/r2/models/link.py
+++ b/r2/r2/models/link.py
@@ -761,10 +761,7 @@ class Link(Thing, Printable):
             if item.deleted and not c.user_is_admin:
                 item.author = DeletedUser()
                 item.as_deleted = True
-                if item._spam:
-                    item.selftext = '[removed by moderator]'
-                else:
-                    item.selftext = '[deleted by user]'
+                item.selftext = '[deleted by author]'
 
             item.votable = not item.archived
 

--- a/r2/r2/models/link.py
+++ b/r2/r2/models/link.py
@@ -1478,7 +1478,10 @@ class Comment(Thing, Printable):
                     # If removed by an admin or moderator, distinguish that
                     # from being deleted by the user.
                     if item._spam:
-                        item.body = '[removed by moderator]'
+                        if c.user_is_admin:
+                            item.body = '[removed by administrator]'
+                        else:
+                            item.body = '[removed by moderator]'
                     else:
                         item.body = '[deleted by author]'
 

--- a/r2/r2/models/link.py
+++ b/r2/r2/models/link.py
@@ -1478,10 +1478,7 @@ class Comment(Thing, Printable):
                     # If removed by an admin or moderator, distinguish that
                     # from being deleted by the user.
                     if item._spam:
-                        if c.user_is_admin:
-                            item.body = '[removed by administrator]'
-                        else:
-                            item.body = '[removed by moderator]'
+                        item.body = '[removed by moderator]'
                     else:
                         item.body = '[deleted by author]'
 


### PR DESCRIPTION
Make these terms more explicit in order to reduce user confusion.