### PR TITLE
Add referrer_url  to the vote generic event

### DIFF
--- a/r2/r2/lib/eventcollector.py
+++ b/r2/r2/lib/eventcollector.py
@@ -123,12 +123,6 @@ class EventQueue(object):
             for name, value in private_data.iteritems():
                 event.add(name, value)
 
-        if context_data:
-            referrer_url = context_data.get('http_referrer')
-            if referrer_url:
-                event.add("referrer_url", referrer_url)
-                event.add("referrer_domain", domain(referrer_url))
-
         self.save_event(event)
 
     @squelch_exceptions
@@ -365,11 +359,6 @@ class EventQueue(object):
             if thing_id36:
                 event.add("thing_id", int(thing_id36, 36))
 
-            referrer_url = request.headers.get('Referer', None)
-            if referrer_url:
-                event.add("referrer_url", referrer_url)
-                event.add("referrer_domain", domain(referrer_url))
-
         self.save_event(event)
 
     @squelch_exceptions
@@ -475,7 +464,12 @@ class EventV2(object):
 
         data["domain"] = request.host
         data["user_agent"] = request.user_agent
-        data["http_referrer"] = request.headers.get("Referer", None)
+
+        http_referrer = request.headers.get("Referer", None)
+        if http_referrer:
+            data["referrer_url"] = http_referrer
+            data["referrer_domain"] = domain(http_referrer)
+
         return data
 
     @classmethod

--- a/r2/r2/lib/eventcollector.py
+++ b/r2/r2/lib/eventcollector.py
@@ -123,6 +123,12 @@ class EventQueue(object):
             for name, value in private_data.iteritems():
                 event.add(name, value)
 
+        if context_data:
+            referrer_url = context_data.get('referer')
+            if referrer_url:
+                event.add("referrer_url", referrer_url)
+                event.add("referrer_domain", domain(referrer_url))
+
         self.save_event(event)
 
     @squelch_exceptions
@@ -342,7 +348,7 @@ class EventQueue(object):
         event.add("sr_id", subreddit._id)
         event.add("sr_name", subreddit.name)
 
-        # Due to the redirect, the request object being sent isn't the 
+        # Due to the redirect, the request object being sent isn't the
         # original, so referrer and action data is missing for certain events
         if request and (event_type == "quarantine_interstitial_view" or
                  event_type == "quarantine_opt_out"):
@@ -469,7 +475,7 @@ class EventV2(object):
 
         data["domain"] = request.host
         data["user_agent"] = request.user_agent
-
+        data["referer"] = request.headers.get("Referer", None)
         return data
 
     @classmethod

--- a/r2/r2/lib/eventcollector.py
+++ b/r2/r2/lib/eventcollector.py
@@ -124,7 +124,7 @@ class EventQueue(object):
                 event.add(name, value)
 
         if context_data:
-            referrer_url = context_data.get('referer')
+            referrer_url = context_data.get('http_referrer')
             if referrer_url:
                 event.add("referrer_url", referrer_url)
                 event.add("referrer_domain", domain(referrer_url))
@@ -475,7 +475,7 @@ class EventV2(object):
 
         data["domain"] = request.host
         data["user_agent"] = request.user_agent
-        data["referer"] = request.headers.get("Referer", None)
+        data["http_referrer"] = request.headers.get("Referer", None)
         return data
 
     @classmethod


### PR DESCRIPTION
This has the side effect of adding the referer as available `context` data for other generic events. 

cc @jophuds 