### PR TITLE
Move generation of S attribute to builder.py

### DIFF
--- a/r2/r2/models/builder.py
+++ b/r2/r2/models/builder.py
@@ -109,6 +109,10 @@ class Builder(object):
                 if sr.can_ban(user):
                     can_ban_set.add(sr_id)
 
+        # hasattr check so no errors occur for non comments
+        links = Link._byID(set(l.link_id for l in items if hasattr(l, 'link_id')),
+                           data=True, return_dict=True, stale=self.stale)
+
         #get likes/dislikes
         try:
             likes = queries.get_likes(user, items)
@@ -173,6 +177,12 @@ class Builder(object):
             except AttributeError:
                 pass
 
+            if hasattr(item, "sr_id") and item.sr_id is not None:
+                w.subreddit = subreddits[item.sr_id]
+
+            if hasattr(item, "link_id") and item.link_id is not None:
+                w.link = links[item.link_id]
+
             if isinstance(item, Comment):
                 if not hasattr(w, 'subreddit'):
                     w.subreddit = item.subreddit_slow
@@ -207,9 +217,6 @@ class Builder(object):
                            {"user": w.author.name}),
                     link="/user/%s" % w.author.name,
                 )
-
-            if hasattr(item, "sr_id") and item.sr_id is not None:
-                w.subreddit = subreddits[item.sr_id]
 
             w.likes = likes.get((user, item))
 

--- a/r2/r2/models/builder.py
+++ b/r2/r2/models/builder.py
@@ -173,6 +173,15 @@ class Builder(object):
             except AttributeError:
                 pass
 
+            if isinstance(item, Comment):
+                if not hasattr(w, 'subreddit'):
+                    w.subreddit = item.subreddit_slow
+                if not hasattr(w, 'link'):
+                    w.link = item.link_slow
+                if item.author_id == w.link.author_id and not w.link._deleted:
+                    add_attr(w.attribs, 'S',
+                             link=w.link.make_permalink(w.subreddit))
+
             if (w.distinguished == 'admin' and w.author):
                 add_attr(w.attribs, 'A')
 

--- a/r2/r2/models/link.py
+++ b/r2/r2/models/link.py
@@ -1437,9 +1437,6 @@ class Comment(Thing, Printable):
 
             if not hasattr(item, 'subreddit'):
                 item.subreddit = item.subreddit_slow
-            if item.author_id == item.link.author_id and not item.link._deleted:
-                add_attr(item.attribs, 'S',
-                         link=item.link.make_permalink(item.subreddit))
             if not hasattr(item, 'target'):
                 item.target = "_top" if cname else None
 


### PR DESCRIPTION
Moves the generation of the S attribute to builder.py, previously in link.py's Comments' `add_props`.

This change makes the S attribute consistent with all the others, and will make it show up in all the places that it is supposed to, such as the inbox, which was the reason why [this bug report was originally filed on /r/bugs](https://redd.it/3oi9n6)

The order of the attributes are kept as they were.
