### PR TITLE
Threaded modmail parameter

### DIFF
--- a/r2/example.ini
+++ b/r2/example.ini
@@ -873,3 +873,4 @@ feature_upgrade_cookies = off
 feature_multireddit_customizations = off
 # Test if `https_testing_img_test` is loaded with an acceptable HTTPS cert according to users' browsers
 feature_test_https_certs = off
+feature_threaded_modmail = {"url": "threaded_view"}

--- a/r2/r2/controllers/listingcontroller.py
+++ b/r2/r2/controllers/listingcontroller.py
@@ -1007,8 +1007,18 @@ class MessageController(ListingController):
         elif not c.default_sr or self.where in ('moderator', 'multi'):
             buttons = (NavButton(_("all"), "inbox"),
                        NavButton(_("unread"), "unread"))
-            return [NavMenu(buttons, base_path = '/message/moderator/',
-                            default = 'inbox', type = "flatlist")]
+            res = [NavMenu(buttons, base_path = '/message/moderator/',
+                           default = 'inbox', type = "flatlist")]
+            if self.subwhere != "unread" and not c.user.pref_threaded_modmail:
+                if feature.is_enabled('threaded_modmail'):
+                    threadbutton = (QueryButton(_('flat view'), None,
+                                    query_param='feature', css_class='threaded'),)
+                else:
+                    threadbutton = (QueryButton(_('threaded view'), "threaded_view",
+                                    query_param='feature', css_class='threaded'),)
+                res.append(NavMenu(threadbutton, base_path = '/message/moderator/',
+                                   default = 'inbox', type = "flatlist"))
+            return res
         return []
 
 

--- a/r2/r2/controllers/listingcontroller.py
+++ b/r2/r2/controllers/listingcontroller.py
@@ -1098,7 +1098,8 @@ class MessageController(ListingController):
             enable_threaded = (
                 (self.where == "moderator" or
                     parent and parent.sr_id) and
-                c.user.pref_threaded_modmail
+                (c.user.pref_threaded_modmail or
+                    feature.is_enabled('threaded_modmail'))
             )
 
             return message_cls(

--- a/r2/r2/controllers/listingcontroller.py
+++ b/r2/r2/controllers/listingcontroller.py
@@ -1005,20 +1005,13 @@ class MessageController(ListingController):
             return [NavMenu(buttons, base_path = '/message/',
                             default = 'inbox', type = "flatlist")]
         elif not c.default_sr or self.where in ('moderator', 'multi'):
-            buttons = (NavButton(_("all"), "inbox"),
-                       NavButton(_("unread"), "unread"))
-            res = [NavMenu(buttons, base_path = '/message/moderator/',
-                           default = 'inbox', type = "flatlist")]
-            if self.subwhere != "unread" and not c.user.pref_threaded_modmail:
-                if feature.is_enabled('threaded_modmail'):
-                    threadbutton = (QueryButton(_('flat view'), None,
-                                    query_param='feature', css_class='threaded'),)
-                else:
-                    threadbutton = (QueryButton(_('threaded view'), "threaded_view",
-                                    query_param='feature', css_class='threaded'),)
-                res.append(NavMenu(threadbutton, base_path = '/message/moderator/',
-                                   default = 'inbox', type = "flatlist"))
-            return res
+            buttons = (NavButton(_("all"), "inbox"),)
+            if not c.user.pref_threaded_modmail:
+                buttons += (QueryButton(_('all - threaded view'), "threaded_view",
+                            query_param='feature', css_class='threaded'),)
+            buttons += (NavButton(_("unread"), "unread"),)
+            return [NavMenu(buttons, base_path = '/message/moderator/',
+                            default = 'inbox', type = "flatlist")]
         return []
 
 


### PR DESCRIPTION
This allows one to get modmail in it's threaded form via the API, which can be useful depending on how the user works.


(Of course, without having to constantly enable the user preference if they for whatever reason want flat modmail)

I've also added two different commits for a GUI to select threaded modmail via the browser. If you'd like the first, just disregard the second. If you'd like the second, squash the third commit with the second. If you'd like neither, disregard both :P.

E: of course, the line in example.ini would have to be moved to reddit's run.ini