### PR TITLE
Add Images to /about/stylesheet for non-mods

### DIFF
--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -2812,20 +2812,26 @@ class CreateSubreddit(Templated):
             )
 
 
-class SubredditStylesheet(Templated):
-    """form for editing or creating subreddit stylesheets"""
-    def __init__(self, site = None,
-                 stylesheet_contents = ''):
-        allow_image_upload = site and not site.quarantine
+class SubredditStylesheetBase(Templated):
+    """Base subreddit stylesheet page."""
+    def __init__(self, stylesheet_contents, **kwargs):
         raw_images = ImagesByWikiPage.get_images(c.site, "config/stylesheet")
         images = {name: make_url_protocol_relative(url)
                   for name, url in raw_images.iteritems()}
-
-        Templated.__init__(
-            self,
-            site=site,
+        super(SubredditStylesheetBase, self).__init__(
             images=images,
             stylesheet_contents=stylesheet_contents,
+            **kwargs
+        )
+
+
+class SubredditStylesheet(SubredditStylesheetBase):
+    """form for editing or creating subreddit stylesheets"""
+    def __init__(self, site=None, stylesheet_contents=''):
+        allow_image_upload = site and not site.quarantine
+        super(SubredditStylesheet, self).__init__(
+            stylesheet_contents=stylesheet_contents,
+            site=site,
             allow_image_upload=allow_image_upload,
         )
 
@@ -2872,14 +2878,10 @@ class SubredditStylesheet(Templated):
                 w.gilded_message = "this comment was fake-gilded"
         return wrapped.render(style="html")
 
-class SubredditStylesheetSource(Templated):
+
+class SubredditStylesheetSource(SubredditStylesheetBase):
     """A view of the unminified source of a subreddit's stylesheet."""
-    def __init__(self, stylesheet_contents):
-        raw_images = ImagesByWikiPage.get_images(c.site, "config/stylesheet")
-        images = {name: make_url_protocol_relative(url)
-                  for name, url in raw_images.iteritems()}
-        Templated.__init__(self, images=images,
-            stylesheet_contents=stylesheet_contents)
+
 
 class AutoModeratorConfig(Templated):
     """A view of a subreddit's AutoModerator configuration."""

--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -2875,7 +2875,11 @@ class SubredditStylesheet(Templated):
 class SubredditStylesheetSource(Templated):
     """A view of the unminified source of a subreddit's stylesheet."""
     def __init__(self, stylesheet_contents):
-        Templated.__init__(self, stylesheet_contents=stylesheet_contents)
+        raw_images = ImagesByWikiPage.get_images(c.site, "config/stylesheet")
+        images = {name: make_url_protocol_relative(url)
+                  for name, url in raw_images.iteritems()}
+        Templated.__init__(self, images=images,
+            stylesheet_contents=stylesheet_contents)
 
 class AutoModeratorConfig(Templated):
     """A view of a subreddit's AutoModerator configuration."""

--- a/r2/r2/public/static/css/highlight.css
+++ b/r2/r2/public/static/css/highlight.css
@@ -8,7 +8,7 @@
 }
 
 /* github.com style (c) Vasily Polovnyov <vast@whiteants.net> - from the highlight.js source */
-pre {
+pre.subreddit-stylesheet-source {
     color: #333;
     background-color: #f8f8ff;
 }

--- a/r2/r2/public/static/css/highlight.css
+++ b/r2/r2/public/static/css/highlight.css
@@ -8,7 +8,7 @@
 }
 
 /* github.com style (c) Vasily Polovnyov <vast@whiteants.net> - from the highlight.js source */
-pre.subreddit-stylesheet-source {
+pre {
     color: #333;
     background-color: #f8f8ff;
 }

--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -4641,6 +4641,8 @@ ul#image-preview-list .description {
 ul#image-preview-list .description pre {
     display: inline;
     padding: 5px;
+    color: #000;
+    background-color: transparent;
 }
 
 

--- a/r2/r2/templates/subredditstylesheet.html
+++ b/r2/r2/templates/subredditstylesheet.html
@@ -28,6 +28,7 @@
 %>
 <%namespace file="utils.html" import="error_field, image_upload"/>
 <%namespace file="printablebuttons.html" import="ynbutton, toggle_button"/>
+<%namespace file="subredditstylesheetbase.html" import="make_li"/>
 
 <div class="stylesheet-customize-container">
   <form
@@ -188,30 +189,6 @@
       /* ]]> */
       </script>
       <ul id="image-preview-list" class="image-list">
-        <%def name="make_li(name='', img=None, prototype=False)">
-          <li ${"style='display:none'" if img is None else ""}>
-            <a href="${img}" class="preview">
-              <img id="img-preview-${name}" src="${img}" 
-                   alt="Image ${name}" title="click to preview"/>
-            </a>
-            <div class="description">
-              <b class="img-name">
-                ${name}
-              </b>
-              <br/>
-              <span>link:</span>
-              <pre class="img-url">url(%%${name}%%)</pre>
-              <br/>
-              <a href="javascript:void(0)" onclick="return paste_url(this)">
-                ${_("paste into stylesheet")}
-              </a>
-              <br/>
-              ${ynbutton(_("delete this image"), _("deleted"),
-                         "delete_sr_img", callback = "delete_img",
-                          hidden_data = dict(img_name = name))}
-            </div>
-          </li>
-          </%def>
         ${make_li(prototype=True)}
         %for name, url in thing.images.iteritems():
            ${make_li(name=name, img=url)}

--- a/r2/r2/templates/subredditstylesheetbase.html
+++ b/r2/r2/templates/subredditstylesheetbase.html
@@ -20,27 +20,30 @@
 ## reddit Inc. All Rights Reserved.
 ###############################################################################
 
-<%!
-    from r2.lib import js
-    from r2.lib.filters import SC_OFF, SC_ON
-    from r2.lib.template_helpers import static
-%>
-<%namespace file="subredditstylesheetbase.html" import="make_li"/>
+<%def name="make_li(name='', img=None, prototype=False, mod=True)">
+  <li ${"style='display:none'" if img is None else ""}>
+    <a href="${img}" class="preview">
+      <img id="img-preview-${name}" src="${img}" 
+           alt="Image ${name}" title="click to preview"/>
+    </a>
+    <div class="description">
+      <b class="img-name">
+        ${name}
+      </b>
+      <br/>
+      <span>link:</span>
+      <pre class="img-url">url(%%${name}%%)</pre>
+      %if mod:
+        <br/>
+        <a href="javascript:void(0)" onclick="return paste_url(this)">
+          ${_("paste into stylesheet")}
+        </a>
+        <br/>
+        ${ynbutton(_("delete this image"), _("deleted"),
+                   "delete_sr_img", callback = "delete_img",
+                    hidden_data = dict(img_name = name))}
+      %endif
+    </div>
+  </li>
+</%def>
 
-<link rel="stylesheet" type="text/css" href="${static("highlight.css")}">
-
-<pre class="subreddit-stylesheet-source">
-<code class="language-css">${unsafe(SC_OFF)}${thing.stylesheet_contents}${unsafe(SC_ON)}</code>
-</pre>
-
-${unsafe(js.use("highlight"))}
-
-%if thing.images:
-  <div id="images">
-    <h2><a name="images">${_("images")}</a></h2>
-    <ul id="image-preview-list" class="image-list">
-      %for name, url in thing.images.iteritems():
-         ${make_li(name=name, img=url, mod=False)}
-      %endfor
-    </ul>
-%endif

--- a/r2/r2/templates/subredditstylesheetsource.html
+++ b/r2/r2/templates/subredditstylesheetsource.html
@@ -33,3 +33,31 @@
 </pre>
 
 ${unsafe(js.use("highlight"))}
+
+%if len(thing.images) > 0:
+  <div id="images">
+    <h2><a name="images">${_("images")}</a></h2>
+    <ul id="image-preview-list" class="image-list">
+      <%def name="make_li(name='', img=None, prototype=False)">
+        <li ${"style='display:none'" if img is None else ""}>
+          <a href="${img}" class="preview">
+            <img id="img-preview-${name}" src="${img}" 
+                 alt="Image ${name}" title="click to preview"/>
+          </a>
+          <div class="description">
+            <b class="img-name">
+              ${name}
+            </b>
+            <br/>
+            <span>link:</span>
+            <pre class="img-url">url(%%${name}%%)</pre>
+            <br/>
+          </div>
+        </li>
+        </%def>
+      ${make_li(prototype=True)}
+      %for name, url in thing.images.iteritems():
+         ${make_li(name=name, img=url)}
+      %endfor
+    </ul>
+%endif

--- a/r2/r2/templates/subredditstylesheetsource.html
+++ b/r2/r2/templates/subredditstylesheetsource.html
@@ -27,13 +27,18 @@
 %>
 <%namespace file="subredditstylesheetbase.html" import="make_li"/>
 
-<link rel="stylesheet" type="text/css" href="${static("highlight.css")}">
 
-<pre class="subreddit-stylesheet-source">
-<code class="language-css">${unsafe(SC_OFF)}${thing.stylesheet_contents}${unsafe(SC_ON)}</code>
-</pre>
+%if thing.stylesheet_contents:
+  <link rel="stylesheet" type="text/css" href="${static("highlight.css")}">
 
-${unsafe(js.use("highlight"))}
+  <pre class="subreddit-stylesheet-source">
+  <code class="language-css">${unsafe(SC_OFF)}${thing.stylesheet_contents}${unsafe(SC_ON)}</code>
+  </pre>
+
+  ${unsafe(js.use("highlight"))}
+%else:
+  <p class="error">${_("there doesn't seem to be anything here")}</p>
+%endif
 
 %if thing.images:
   <div id="images">


### PR DESCRIPTION
Adds images to /about/stylesheets for easy view, even when a non mod, since the images were already accessible via inspect element as well as via the JSON template, as semi-wanted on /r/csshelp numerous times. Copypasta is beautiful :P