### PR TITLE
Don't mark the mute message for translation

### DIFF
--- a/r2/r2/models/subreddit.py
+++ b/r2/r2/models/subreddit.py
@@ -2801,9 +2801,9 @@ class MutedAccountsBySubreddit(object):
 
         #if the user has interacted with the subreddit before, message them
         if user.has_interacted_with(sr):
-            subject = _("You have been muted from r/%(subredditname)s")
+            subject = "You have been muted from r/%(subredditname)s"
             subject %= dict(subredditname=sr.name)
-            message = _("You have been [temporarily muted](%(muting_link)s) "
+            message = ("You have been [temporarily muted](%(muting_link)s) "
                 "from r/%(subredditname)s. You will not be able to message "
                 "the moderators of r/%(subredditname)s for %(num_hours)s hours.")
             message %= dict(


### PR DESCRIPTION
When marked for translation the message would get sent in the mom's language. That shouldn't happen. Reported [here](http://www.reddit.com/r/bugs/comments/3s6uts).