### PR TITLE
Add '/u/reddit` to share-via-email placeholders

### DIFF
--- a/r2/r2/public/static/js/post-sharing.js
+++ b/r2/r2/public/static/js/post-sharing.js
@@ -65,7 +65,7 @@
         '<input class="post-sharing-recipient-input c-form-control" ' +
                'ref="$shareTo" ' +
                'name="recipient" type="text" ' +
-               'placeholder="name@example.com, name@example.com">' +
+               'placeholder="name@example.com, /u/reddit">' +
         feedbackTemplate({ ref: '$shareToFeedback' }) +
       '</div>' +
       '<div class="c-form-group">' +


### PR DESCRIPTION
When you click the "share" link below a post, you have several options. One of them is to share it via email (http://imgur.com/8rLzrHP). You can use this to share posts with other redditors, but it's not obvious (https://www.reddit.com/r/ModSupport/comments/3sbpjr/why_cant_we_share_posts_with_other_redditor/). 

I suggest adding `/u/reddit` as one of the placeholders so sharers know usernames are an option.