### PR TITLE
GUI improvements for the force add moderators section for admins

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -1036,7 +1036,8 @@ class ApiController(RedditController):
         else:
             permissions = None
 
-        if type == "moderator_invite" and container.is_moderator(friend):
+        if (type in ("moderator_invite", "moderator") and
+                container.is_moderator(friend)):
             c.errors.add(errors.ALREADY_MODERATOR, field="name")
             form.set_error(errors.ALREADY_MODERATOR, "name")
             return

--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -1163,6 +1163,11 @@ class ApiController(RedditController):
             table = jquery("." + type + "-table").show().find("table")
             table.insert_table_rows(user_row, index=index)
             table.find(".notfound").hide()
+            # hide the listing in the invite table if it exists
+            if type == 'moderator':
+                table = jquery(".moderator_invite-table")
+                userspan = table.find('a[href$="/user/%s/"]' % friend.name)
+                userspan.parent().parent().parent().hide()
 
         if type == "banned":
             # If the ban is new or has had the duration changed,

--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -9724,6 +9724,7 @@ body.post-under-6h-old .gilded-icon {
     text-align: right;
     width: 36ex;
 }
+#moderator .permissions,
 #moderator_invite .permissions { width: 30ex; }
 .permissions > form { display: none; }
 

--- a/r2/r2/templates/modlisting.html
+++ b/r2/r2/templates/modlisting.html
@@ -22,7 +22,6 @@
 
 <%namespace file="printablebuttons.html" import="ynbutton" />
 <%namespace file="userlisting.html" import="add_form, listing"/>
-<%namespace file="utils.html" import="error_field"/>
 
 <div class="${thing._class} usertable">
   %if thing.can_remove_self:
@@ -52,11 +51,7 @@
   %endif
 
   %if thing.addable and thing.has_add_form:
-    <%call expr="add_form(thing.form_title, thing.destination, thing.type, thing.container_name, verb=_('add'))">
-      ${error_field("ALREADY_MODERATOR", "name")}
-      ${error_field("BANNED_FROM_SUBREDDIT", "name")}
-      ${error_field("MUTED_FROM_SUBREDDIT", "name")}
-    </%call>
+    ${add_form(thing.form_title, thing.destination, thing.type, thing.container_name)}
   %endif
   ${listing()}
 </div>

--- a/r2/r2/templates/modlisting.html
+++ b/r2/r2/templates/modlisting.html
@@ -51,7 +51,7 @@
   %endif
 
   %if thing.addable and thing.has_add_form:
-    ${add_form(thing.form_title, thing.destination, thing.type, thing.container_name)}
+    ${add_form(thing.form_title, thing.destination, thing.type, thing.container_name, permissions_form=thing.permissions_form)}
   %endif
   ${listing()}
 </div>


### PR DESCRIPTION
Admins can forcibly add moderators to subreddits with their own tool. However; the error fields that this commit removes were duplicated (because they are already retrieved from the `<%call>` to [`userlisting.html`](https://github.com/reddit/reddit/blob/master/r2/r2/templates/userlisting.html#L79)), and when an admin encounters said error(s), it shows up twice because of this.

This stops the error from appearing twice.

This also adds a permissions form for admins to use if they wish to do so, as well as makes the ALREADY_MODERATOR error actually return when admins forcibly add mods. 

While the last commit probably wouldn't have real use in reddit itself, there are potential "look and feel" improvements (excess mod log entries), and can help those that wish to run their own reddit instance.
