### PR TITLE
Add subreddit creator to subreddit json template

### DIFF
--- a/r2/r2/controllers/front.py
+++ b/r2/r2/controllers/front.py
@@ -879,7 +879,8 @@ class FrontController(RedditController):
         Data includes the subscriber count, description, and header image."""
         if not is_api() or isinstance(c.site, FakeSubreddit):
             return self.abort404()
-        item = Wrapped(c.site, accounts_active_count=c.site.accounts_active)
+        item = Wrapped(c.site, author=c.site.author_slow,
+                       accounts_active_count=c.site.accounts_active)
         Subreddit.add_props(c.user, [item])
         return Reddit(content=item).render()
 

--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -283,6 +283,7 @@ class SubredditJsonTemplate(ThingJsonTemplate):
         collapse_deleted_comments="collapse_deleted_comments",
         comment_score_hide_mins="comment_score_hide_mins",
         # community_rules="community_rules",
+        creator="author",
         description="description",
         description_html="description_html",
         display_name="name",
@@ -397,6 +398,12 @@ class SubredditJsonTemplate(ThingJsonTemplate):
                 return c.user.use_subreddit_style(thing)
             else:
                 return True
+        elif attr == 'author':
+            if not thing.author:
+                return thing.author
+            elif thing.author._deleted:
+                return '[deleted]'
+            return thing.author.name
         else:
             return ThingJsonTemplate.thing_attr(self, thing, attr)
 


### PR DESCRIPTION
Anybody can view the subreddit's creator via the creator text on the sidebar. Somewhat surprisingly, this is not included in the JSON response. This commit puts it in the JSON response.