### PR TITLE
Add /api/quarantine_opt[in|out] to apidocs

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -3721,6 +3721,7 @@ class ApiController(RedditController):
         VModhash(),
         sr=VSRByName('sr_name'),
     )
+    @api_doc(api_section.subreddits)
     def POST_quarantine_optout(self, sr):
         """Opt out from a quarantined subreddit"""
         if not sr:
@@ -3737,6 +3738,7 @@ class ApiController(RedditController):
         VModhash(),
         sr=VSRByName('sr_name'),
     )
+    @api_doc(api_section.subreddits)
     def POST_quarantine_optin(self, sr):
         """Opt in to a quarantined subreddit"""
         if not sr:


### PR DESCRIPTION
Adds /api/quarantine_optin and /quarantine_optout to the api docs, since it's kinda weird that they aren't there. In restrospect, you probably will want to add to the API rules that this should be done only under user supervision, like voting.

On a separate note, you make want to make it so that these functions will return an error if the subreddit isn't quarantined to begin with.
