### PR TITLE
FIX: #1319 discover user even when running without sudo

### DIFF
--- a/install-reddit.sh
+++ b/install-reddit.sh
@@ -48,7 +48,8 @@ set -e
 # Configuration
 ###############################################################################
 # which user to install the code for; defaults to the user invoking this script
-REDDIT_USER=${REDDIT_USER:-$SUDO_USER}
+CURRENT_USER=${SUDO_USER:-$USER}
+REDDIT_USER=${REDDIT_USER:-$CURRENT_USER}
 
 # the group to run reddit code as; must exist already
 REDDIT_GROUP=${REDDIT_GROUP:-nogroup}


### PR DESCRIPTION
I've just launched a fresh instance on Digital Ocean, these guys give you a Ubuntu instance with root ssh access via a private key. I've then ran the install script and sure enough it failed because of #1319 so yeah, had I've exported REDDIT_USER it would have worked, but why not fix it without me having to configure stuff? 

The suggested patch simply takes the value of USER if no SUDO_USER environment variable present. 

The installer is happier, and so is it's users.