### PR TITLE
Disable voting arrows on archived comments

### DIFF
--- a/r2/r2/templates/comment_skeleton.html
+++ b/r2/r2/templates/comment_skeleton.html
@@ -23,8 +23,8 @@
 <%inherit file="printable.html"/>
 <%namespace file="utils.html" import="plain_link" />
 
-<%def name="midcol(display=True, cls = '')">
-  ${parent.midcol(display=display, cls = cls)}
+<%def name="midcol(cls = '')">
+  ${parent.midcol(display=getattr(thing, "votable", True), cls = cls)}
 </%def>
 
 <%def name="tagline()">


### PR DESCRIPTION
This PR is fairly straightforward, disabling the voting arrows on comments which have been archived. However, it does not impact the appearance of voting arrows on top-level posts, as they may take on a strange appearance when rendered as part of a listing of multiple posts given the disparity in formatting from non-archived posts.