### PR TITLE
Allow `resize` property in CSS filter

### DIFF
--- a/r2/r2/lib/cssfilter.py
+++ b/r2/r2/lib/cssfilter.py
@@ -248,6 +248,7 @@ SAFE_PROPERTIES = {
     "pointer-events",
     "position",
     "quotes",
+    "resize",
     "richness",
     "right",
     "speak",


### PR DESCRIPTION
Just a small hitch I happened upon when submitting a subreddit style recently. If it's not secure, feel free to strike it down! I can't imagine any insecurity, however.

Defined by the W3C here: https://drafts.csswg.org/css-ui-3/#resize
Mozilla summary: https://developer.mozilla.org/en-US/docs/Web/CSS/resize
Browser support: http://caniuse.com/#feat=css-resize