### PR TITLE
Non mod modmail

### DIFF
--- a/r2/r2/models/link.py
+++ b/r2/r2/models/link.py
@@ -1999,7 +1999,7 @@ class Message(Thing, Printable):
         # also, only global admins can be message spammed.
         if not skip_inbox and to and (not m._spam or to.name in g.admins):
             # if "to" is not a sr moderator they need to be notified
-            if not sr_id or not sr.is_moderator(to):
+            if not sr_id or not sr.is_moderator_with_perms(to, 'mail'):
                 # Record the inbox relation, but don't give the user
                 # an orangered, if they PM themselves.
                 # Don't notify on PMs from blocked users, either

--- a/r2/r2/models/link.py
+++ b/r2/r2/models/link.py
@@ -2202,7 +2202,8 @@ class Message(Thing, Printable):
                 item.user_is_recipient = not user_is_sender
                 item.user_is_moderator = item.sr_id in user_mod_sr_ids
 
-                if sr_colors and item.user_is_moderator:
+                if (sr_colors and item.user_is_moderator and
+                    item.subreddit.is_moderator_with_perms(c.user, 'mail')):
                     item.accent_color = sr_colors.get(item.sr_id)
 
                 if item.subreddit.is_muted(item.author):

--- a/r2/r2/models/link.py
+++ b/r2/r2/models/link.py
@@ -1987,7 +1987,7 @@ class Message(Thing, Printable):
             if parent or to_subreddit or from_sr:
                 inbox_rel.append(ModeratorInbox._add(sr, m, 'inbox'))
 
-            if sr.is_moderator(author):
+            if sr.is_moderator_with_perms(author, 'mail'):
                 m.distinguished = 'yes'
                 m._commit()
 

--- a/r2/r2/models/link.py
+++ b/r2/r2/models/link.py
@@ -2311,7 +2311,8 @@ class Message(Thing, Printable):
                     item.body = _('[unblock user to see this message]')
 
             if item.sr_id and item.to:
-                item.to_is_moderator = item.to._id in mods_by_srid[item.sr_id]
+                item.to_is_moderator = (item.to._id in mods_by_srid[item.sr_id]
+                                        and item.subreddit.is_moderator_with_perms(item.to, 'mail'))
 
         if to_set_unread:
             unread_by_class = defaultdict(list)


### PR DESCRIPTION
@bsimpson63 asked me to separate this from #1475 

I don't really know what logisitics for non mod modmail were wanted them so like in 1475 I just have separate commits with increasing changes. First commit fixes the bug; the rest modify behavior as necessary.

It can be argued that L2206 and L2316 can be slow, however; the python2 (not sure if 3, but 2 is what matters) interpreter does not evaluate functions in boolean operator based comparisons (probably using the wrong terminology >.>) until the statement before the operator and the operator itself are evaluated, eg:

    >>> setup = """
    ... from time import sleep
    ... def foo():
    ...     sleep(10)
    ...     return True
    ... """
    >>> from timeit import timeit
    >>> timeit("bool(False and foo())", setup=setup)
    1.9073486328125e-06
    >>> timeit("bool(True and foo())", setup=setup, number=1)
    10.010693073272705

So they are only used if the other two checks pass. Or all commits but the first may not even be necessary. I just did them to make the behavior "fit".