### PR TITLE
Allow breaks mid-word in sidebar (closes #1491)

### DIFF
--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -497,6 +497,7 @@ ul.flat-vert {text-align: left;}
     background-color: white; 
     margin: 0px 5px 0 5px;
     width: 300px;
+    word-wrap: break-word;
 }
 
 .side .spacer {


### PR DESCRIPTION
In cases where text extends past the bounds of `.side` without a space/hyphen/other breakable point, `break-word` gives the engine permission to break at an arbitrary point (usually as close to the bound as it can).
