### PR TITLE
Change border to outline (closes #1407)

### DIFF
--- a/r2/r2/public/static/js/embed/comment-embed.js
+++ b/r2/r2/public/static/js/embed/comment-embed.js
@@ -77,9 +77,9 @@
       iframe.style.margin = '10px 0';
       iframe.style.borderRadius = '5px';
       iframe.style.boxShadow = '0 0 5px 0.5px rgba(0, 0, 0, 0.05)';
-      iframe.style.borderColor = 'rgba(199,199,199, 0.55)';
-      iframe.style.borderWidth = '1px';
-      iframe.style.borderStyle = 'solid';
+      iframe.style.outlineColor = 'rgba(199,199,199, 0.55)';
+      iframe.style.outlineWidth = '1px';
+      iframe.style.outlineStyle = 'solid';
       iframe.style.boxSizing = 'border-box';
       iframe.src = getEmbedUrl(commentUrl, embed);
 


### PR DESCRIPTION
Using `border` encroaches on the content and can lead to a scrollable iFrame (using middle click scrolling). `outline` doesn't cover within the frame, and therefore doesn't lead to scrolling. Closes #1407.
