### PR TITLE
AMA Supercross 2016 Live Oakland RD4 stream online

### DIFF
--- a/r2/r2/models/promo.py
+++ b/r2/r2/models/promo.py
@@ -39,7 +39,9 @@ from r2.models.subreddit import Subreddit, Frontpage
 PROMOTE_STATUS = Enum("unpaid", "unseen", "accepted", "rejected",
                       "pending", "promoted", "finished")
 
-class PriorityLevel(object):
+PROMOTE_COST_BASIS = Enum('fixed_cpm', 'cpm', 'cpc',)
+
+
     name = ''
     _text = N_('')
     _description = N_('')


### PR DESCRIPTION
AMA Supercross 2016 Live Oakland RD4 stream online

WEB LINK : http://allsportsstream.com/ama-supercross/

TV LINK 1 : http://www.edigitalplace.com/amember/aff/go/anis321pallab/?i=139

TV LINK 2 : http://bannermedianetworks.com.es/scripts/click.php?a_aid=48602&a_bid=e7d69b52

TICKETS LINK : http://ticketnetwork.7eer.net/c/132063/204780/2322

BLOG LINK 1 : http://sportslivestreamzone.blogspot.com/

BLOG LINK 2 : http://monsterenergyamasupercrosslive.blogspot.com/

BLOG LINK 3 : http://amasupercrosssandiegolive.blogspot.com/

FACEBOOK LINK : https://www.facebook.com/Sports-Tv-102117566639941/

TWITTER LINK : https://twitter.com/AllsportsStream

TV Schedule :
Event : AMA Supercross
Date : Saturday, 30th January, 2016
Time : Main Event - 10:00 PM ET
Venue : O.Co Coliseum, Oakland, CA
Live : Fuel TV, FOX Sports

Why pay over $90.00 a month for cable or satellite TV services? Our proprietary technology instantly turns your computer into a Super TV! FOX Sports 1 and FOX Sports 2, launched in August by FOX Sports, are set to deliver more than 291 hours of Feld Motor Sports property programming per year to their multi-sport audience, according to Feld. FOX Sports 1 is available in more than 90 million homes and FOX Sports 2 is in more than 40 million. Included in the agreement are 115 hours of original programming and 51 hours of live coverage. Now you can watch 4000+ worldwide channels on your PC - Sports, News, Movies, Music, Weather, Kids Channels, Educational, Shopping, +Digital Radio Stations and much, much more! You can also watch the Big Games LIVE without any additional fee or subscription! No Hardware to Install! Works anywhere in the world!