### PR TITLE
Add community rule placeholders

### DIFF
--- a/r2/r2/lib/automoderator.py
+++ b/r2/r2/lib/automoderator.py
@@ -90,6 +90,20 @@ rules_by_subreddit = {}
 
 unnumbered_placeholders_regex = re.compile(r"\{\{(match(?:-[^\d-]+?)?)\}\}")
 match_placeholders_regex = re.compile(r"\{\{match-(?:([^}]+?)-)?(\d+)\}\}")
+
+def generate_community_rule_placeholders(subreddit):
+    def _combine_rule(rule):
+        combined_rule = "**{0}**\n\n".format(rule['short_name'])
+        for line in rule['description'].split('\n'):
+            combined_rule += "> {0}".format(line)
+        return combined_rule
+    rule_replacements = {}
+    for rule in subreddit.community_rules:
+        rule_replacements['{{rule_{0}_title}}'.format((rule['priority'] + 1))] = rule['short_name']
+        rule_replacements['{{rule_{0}_description}}'.format((rule['priority'] + 1))] = rule['description']
+        rule_replacements['{{rule_{0}}'.format((rule['priority'] + 1))] = _combine_rule(rule)
+    return rule_replacements
+
 def replace_placeholders(string, data, matches):
     """Replace placeholders in the string with appropriate values."""
     item = data["item"]
@@ -98,6 +112,8 @@ def replace_placeholders(string, data, matches):
         "{{body}}": getattr(item, "body", ""),
         "{{subreddit}}": data["subreddit"].name,
     }
+    
+    replacements.update(generate_community_rule_placeholders(data["subreddit"]))
 
     if isinstance(item, Comment):
         context = None


### PR DESCRIPTION
As I suggested [here](https://www.reddit.com/r/AutoModerator/comments/42toej/feature_suggestion_shorthand_for_subreddit_rules/). I'm doing this entirely off mobile via reading past commits, so you might want to do a more thorough check than usual.

~~If you'd like I can also make it return an error to the mod that is editing the config (which IIRC is usually done for syntax errors) if a rule that they chose doesn't actually exist.~~ After looking into it, while definitely doable, I don't think that's a good thing to do, since you'd have to take into account the fact that rules can change, as well as the fact that the status of "when/howoften" is it checked becomes an issue. It seems safer to allow the mods to see  the fact that rules changed when they see a stray comment.