### PR TITLE
Update captcha.py

### DIFF
--- a/r2/r2/lib/captcha.py
+++ b/r2/r2/lib/captcha.py
@@ -26,7 +26,6 @@ import random, string
 
 from pylons import app_globals as g
 
-from Captcha.Base import randomIdentifier
 from Captcha.Visual import Text, Backgrounds, Distortions, ImageCaptcha
 
 from r2.lib.cache import make_key
@@ -48,10 +47,10 @@ class RandCaptcha(ImageCaptcha):
                  Distortions.SineWarp()))
 
 def get_iden():
-    return self.randomIdentifier(length=IDEN_LENGTH)
+    return randomIdentifier(length=IDEN_LENGTH)
 
 def make_solution():
-    return self.randomIdentifier(alphabet=string.ascii_letters, length = SOL_LENGTH).upper()
+    return randomIdentifier(alphabet=string.ascii_letters, length = SOL_LENGTH).upper()
 
 def randomIdentifier(alphabet = string.ascii_letters + string.digits,
                      length = 24):

--- a/r2/r2/lib/captcha.py
+++ b/r2/r2/lib/captcha.py
@@ -48,10 +48,14 @@ class RandCaptcha(ImageCaptcha):
                  Distortions.SineWarp()))
 
 def get_iden():
-    return randomIdentifier(length=IDEN_LENGTH)
+    return self.randomIdentifier(length=IDEN_LENGTH)
 
 def make_solution():
-    return randomIdentifier(alphabet=string.ascii_letters, length = SOL_LENGTH).upper()
+    return self.randomIdentifier(alphabet=string.ascii_letters, length = SOL_LENGTH).upper()
+
+def randomIdentifier(alphabet = string.ascii_letters + string.digits,
+                     length = 24):
+    return "".join([random.SecureRandom.choice(alphabet) for i in xrange(length)])
 
 def get_image(iden):
     key = make_key(iden)


### PR DESCRIPTION
PyCaptcha's `randomIdentifier()` uses `random.choice` which is a PRNG based on the Mersenne Twister. 

Let's use a CSPRNG instead. Otherwise this attack exists:

1. Get several (624) subsequent captcha images.
2. Get a human to translate them.
3. Crack the MT seed.
4. Bypass the CAPTCHA forever without human intervention.