### PR TITLE
Add -ms-interpolation-mode to the CSS filter

### DIFF
--- a/r2/r2/lib/cssfilter.py
+++ b/r2/r2/lib/cssfilter.py
@@ -198,6 +198,7 @@ SAFE_PROPERTIES = {
     "image-orientation",
     "image-rendering",
     "image-resolution",
+    "interpolation-mode", # IE exclusive as "-ms-interpolation-mode"
     "justify-content",
     "left",
     "letter-spacing",


### PR DESCRIPTION
Recently, I was trying to make resized images appear pixelated. This can be easily accomplished with the [`image-rendering`](https://developer.mozilla.org/en-US/docs/Web/CSS/image-rendering) tag, which is already allowed through Reddit's filter. Unfortunately, is not supported by IE. Fortunately, the nonstandard tag [`-ms-interpolation-mode`](https://msdn.microsoft.com/en-us/library/ff521095.aspx) (mentioned as a substitute in the MDK spec) provides almost exactly the same functionality. It just needs to be added to the CSS filter.
