### PR TITLE
Patch VSubredditName from experiencing a UnidcodeDecodeError

### DIFF
--- a/r2/r2/lib/validator/validator.py
+++ b/r2/r2/lib/validator/validator.py
@@ -701,7 +701,10 @@ class VSubredditName(VRequired):
             name, allow_language_srs=self.allow_language_srs)
         if not valid_name:
             self.set_error(self._error, code=400)
-        return str(name)
+        # if it's not valid, don't bother returning it
+        # because it could potentially end in a
+        # UnicodeDecodeError, and nothing would use it anyway
+        return str(name) if valid_name else ""
 
     def param_docs(self):
         return {


### PR DESCRIPTION
Resolve a potential `UnicodeDecodeError` in `VSubredditName`. Since names that would cause these errors aren't considered valid by the regex check in `Subreddit.is_valid_name`, and if a name is invalid it's not used in any action, it's safe to wipe them with a `""`. Originally reported [here](https://www.reddit.com/r/bugs/comments/46sxg5/that_500_error_when_trying_to_create_a_subreddit/)

E: As can be seen by [/r/13steinj_chars_test/](https://www.reddit.com/r/13steinj_chars_test/), there is no issue on any other fields.