### PR TITLE
Fix SubredditSettingsTemplate key_color attribute

### DIFF
--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -1435,7 +1435,7 @@ class SubredditSettingsTemplate(ThingJsonTemplate):
 
         # remove this when feature is enabled and use _data_attrs instead
         if feature.is_enabled('mobile_settings'):
-            data['key_color'] = self.thing_attr(thing, 'key_color')
+            data['key_color'] = self.thing_attr(thing, 'site.key_color')
         if feature.is_enabled('related_subreddits'):
             data['related_subreddits'] = self.thing_attr(thing, 'related_subreddits')
 


### PR DESCRIPTION
The mobile key color is being set to null since it's being incorrectly determined. [Reported here](https://www.reddit.com/r/redditdev/comments/47ajao/praw_modifying_new_mobile_settings/).
