### PR TITLE
Add vid.me to case-sensitive domains

### DIFF
--- a/r2/example.ini
+++ b/r2/example.ini
@@ -496,7 +496,7 @@ static_path = /static/
 # Just a list of words. Used by errorlog.py to make up names for new errors.
 words_file = /usr/dict/words
 # domains that we consider URLs case sensitive for repost detection purposes
-case_sensitive_domains = i.imgur.com, youtube.com
+case_sensitive_domains = i.imgur.com, youtube.com, vid.me
 # Domains that we know are friendly and host raw image files
 known_image_domains = i.imgur.com, giant.gfycat.com, pbs.twimg.com, upload.wikimedia.org
 # whether to load reddit private code (a hack until we structure it better)


### PR DESCRIPTION
The ID string on vid.me urls are case sensitive, and it's been around long enough there are false positives starting to show up in "other discussion" tabs
