### PR TITLE
Precise bans

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -954,7 +954,7 @@ class ApiController(RedditController):
         type_and_permissions=VPermissions('type', 'permissions'),
         note=VLength('note', 300),
         ban_reason=VLength('ban_reason', 100),
-        duration=VInt('duration', min=1, max=999),
+        duration=VFloat('duration', min=(1.0/24), max=999),
         ban_message=VMarkdownLength('ban_message', max_length=1000,
             empty_error=None),
     )

--- a/r2/r2/lib/validator/validator.py
+++ b/r2/r2/lib/validator/validator.py
@@ -1964,6 +1964,31 @@ class VFloat(VNumber):
     def cast(self, val):
         return float(val)
 
+    def param_docs(self):
+        # round self.min and self.max for human readable docs
+        min_num = self.round_for_docs(self.min)
+        max_num = self.round_for_docs(self.max)
+        if self.min is not None and self.max is not None:
+            description = "a floating point number or integer between %d and %d" % (min_num, max_num)
+        elif self.min is not None:
+            description = "a floating point number or integer greater than %d" % min_num
+        elif self.max is not None:
+            description = "a floating point number or integer less than %d" % max_num
+        else:
+            description = "a floating point number or integer"
+
+        if self.num_default is not None:
+            description += " (default: %d)" % self.num_default
+
+        return {self.param: description}
+
+    @staticmethod
+    def round_for_docs(num):
+        if num is None:
+            return num
+        ret = round(num, 3)
+        return ret if not ret.is_integer() else int(ret)
+            
 
 class VDecimal(VNumber):
     def cast(self, val):

--- a/r2/r2/models/listing.py
+++ b/r2/r2/models/listing.py
@@ -185,12 +185,17 @@ class BannedListing(UserListing):
 
     @classmethod
     def populate_from_tempbans(cls, item, tempbans=None):
+        # 84600.0 is the number of seconds in a day
+        rounded_days = lambda td: round((td.total_seconds() / (86400.0)), 1)
+        def pretty_days(td):
+            ret = rounded_days(td)
+            return ret if not ret.is_integer() else int(ret)
         if not tempbans:
             return
         time = tempbans.get(item.user.name)
         if time:
             delay = time - datetime.now(g.tz)
-            item.tempban = max(delay.days, 0)
+            item.tempban = max(pretty_days(delay), 0)
 
     @property
     def form_title(self):


### PR DESCRIPTION
Allow mods to choose bans that are more precise, minimum of an hour.