### PR TITLE
reddit.less: listing chooser fix

### DIFF
--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -9746,8 +9746,8 @@ body.with-listing-chooser {
     }
 
     .listing-chooser {
-        position: absolute;
-        top: 65px;
+        position: fixed;
+        top: 0;
         left: 0;
         bottom: 0;
         width: @lc-width;
@@ -9859,6 +9859,10 @@ body.with-listing-chooser {
 }
 
 .listing-chooser {
+    .contents {
+        top: 65px;
+        position: relative;
+    }
     h3 {
         color: #777;
         text-align: right;


### PR DESCRIPTION
listing chooser sidebar now does have a fixed position and becomes sticky, so it does not scroll with the page.
its contents are intended instead so it looks prettier.
what's the purpose of having a sidebar that displays through the whole page but stays on top?

gif before: https://i.gyazo.com/077b2a731b2895925453237739d89269.gif
gif after: https://i.gyazo.com/a0b1d032616237bc62ab9d11d510c8d9.gif