### PR TITLE
Fix issue when 'compiling' CSS

### DIFF
--- a/r2/Makefile
+++ b/r2/Makefile
@@ -87,8 +87,8 @@ clean_ini:
 
 #################### CSS file lists
 SPRITED_STYLESHEETS += reddit.less modtools.less
-LESS_STYLESHEETS := wiki.less adminbar.less policies.less reddit-embed.less compact.css
-OTHER_STYLESHEETS := mobile.css highlight.css
+LESS_STYLESHEETS := wiki.less adminbar.less policies.less reddit-embed.less
+OTHER_STYLESHEETS := mobile.css highlight.css compact.css
 
 #################### Static Files
 STATIC_ROOT := r2/public

--- a/r2/Makefile
+++ b/r2/Makefile
@@ -86,8 +86,8 @@ clean_ini:
 	rm $(INIFILES)
 
 #################### CSS file lists
-SPRITED_STYLESHEETS += reddit.less compact.css modtools.less
-LESS_STYLESHEETS := wiki.less adminbar.less policies.less reddit-embed.less
+SPRITED_STYLESHEETS += reddit.less modtools.less
+LESS_STYLESHEETS := wiki.less adminbar.less policies.less reddit-embed.less compact.css
 OTHER_STYLESHEETS := mobile.css highlight.css
 
 #################### Static Files
@@ -134,7 +134,7 @@ CSS_SOURCE_DIR := $(STATIC_BUILD_DIR)/css
 PROCESSED_SPRITED_STYLESHEETS := $(addprefix $(STATIC_BUILD_DIR)/, $(SPRITED_STYLESHEETS:.less=.css))
 SPRITES := $(addprefix $(STATIC_BUILD_DIR)/, $(patsubst %.css,sprite-%.png, $(SPRITED_STYLESHEETS:.less=.css)))
 
-LESS_OUTPUTS := $(addprefix $(STATIC_BUILD_DIR)/, $(patsubst %.less,%.css, $(LESS_STYLESHEETS)))
+LESS_OUTPUTS := $(addprefix $(STATIC_BUILD_DIR)/, $(patsubst %.less,%.css, $(LESS_STYLESHEETS) $(SPRITED_STYLESHEETS)))
 
 MINIFIED_OTHER_STYLESHEETS := $(addprefix $(STATIC_BUILD_DIR)/, $(OTHER_STYLESHEETS))
 


### PR DESCRIPTION
The change is meant to fix the error `No rule to make target 'build/public/static/reddit.css'` when running `make` or `make css`:

```
$ make clean && make css
[+] including definitions from Makefile.py
rm -f ./r2/lib/mr_tools/_mr_tools.c ./r2/lib/wrapped.c ./r2/lib/utils/comment_tree_utils.c ./r2/lib/utils/_utils.c ./r2/lib/sgm.c ./r2/lib/db/_sorts.c ./r2/lib/mr_tools/_mr_tools.so ./r2/lib/wrapped.so ./r2/lib/utils/comment_tree_utils.so ./r2/lib/utils/_utils.so ./
r2/lib/sgm.so ./r2/lib/db/_sorts.so
rm -f r2/lib/generated_strings.py
rm -rf build/static-buildstamp build/public/static  build/mangle-buildstamp
[+] including definitions from Makefile.py
cp -ruTL r2/public build/public
touch build/static-buildstamp
make: *** No rule to make target 'build/public/static/reddit.css', needed by 'css'.  Stop.
```
