### PR TITLE
Add distinguish classes to links and comments

### DIFF
--- a/r2/r2/templates/comment_skeleton.html
+++ b/r2/r2/templates/comment_skeleton.html
@@ -41,7 +41,14 @@
 </%def>
 
 <%def name="thing_css_class(what)">
-  ${parent.thing_css_class(what)} ${"stickied" if getattr(thing, 'is_sticky', None) else ""} ${"collapsed" if thing.collapsed else "noncollapsed"} ${"collapsed-for-reason" if hasattr(thing, "collapsed_reason") else ""}
+  ${parent.thing_css_class(what)} ${"stickied" if getattr(thing, 'is_sticky', None) else ""} ${"collapsed" if thing.collapsed else "noncollapsed"} ${"collapsed-for-reason" if hasattr(thing, "collapsed_reason") else ""} ${distinguished_css_class(what)}
+</%def>
+
+<%def name="distinguished_css_class(what)">
+  <% distinguish_type = getattr(what, 'distinguished', None) %>
+  %if distinguish_type and distinguish_type not in ('gold', 'gold-auto'):
+    ${'distinguished distinguished-%s' % distinguish_type}
+  %endif
 </%def>
 
 <%def name="thing_data_attributes(what)">

--- a/r2/r2/templates/link.html
+++ b/r2/r2/templates/link.html
@@ -153,8 +153,15 @@
 </%def>
 
 <%def name="thing_css_class(what)" buffered="True">
-  ${parent.thing_css_class(what)} ${"over18" if thing.over_18 else ""} ${thing.visited and 'visited' or ''}
+  ${parent.thing_css_class(what)} ${"over18" if thing.over_18 else ""} ${thing.visited and 'visited' or ''} ${distinguished_css_class(what)}
   ${get_linkflair_css_classes(thing, on_class="linkflair", off_class="")}
+</%def>
+
+<%def name="distinguished_css_class(what)" buffered="True">
+  <% distinguish_type = getattr(what, 'distinguished', None) %>
+  %if distinguish_type and distinguish_type not in ('gold', 'gold-auto'):
+    ${'distinguished distinguished-%s' % distinguish_type}
+  %endif
 </%def>
 
 <%def name="thing_data_attributes(what)">


### PR DESCRIPTION
Adds "distinguished" and "distinguished-(type)" classes to links and comments.

As requested [here](https://www.reddit.com/r/ideasfortheadmins/comments/48pq2i/adding_a_distinguished_or_similar_class_to_links/)
