### PR TITLE
Decode loid cookies on screenview events

### DIFF
--- a/r2/r2/lib/loid.py
+++ b/r2/r2/lib/loid.py
@@ -78,7 +78,7 @@ class LoId(object):
             ):
                 d = cookie_attrs.copy()
                 d.setdefault("expires", expires)
-                context.cookies.add(name, quote(value), **d)
+                context.cookies.add(name, value, **d)
 
     def to_dict(self, prefix=None):
         """Serialize LoId, generally for use in the event pipeline."""

--- a/r2/r2/public/static/js/analytics.js
+++ b/r2/r2/public/static/js/analytics.js
@@ -44,7 +44,7 @@ r.analytics = {
       if (loggedOutData && loggedOutData.loid) {
         r.analytics.contextData.loid = loggedOutData.loid;
         if (loggedOutData.loidcreated) {
-          r.analytics.contextData.loid_created = loggedOutData.loidcreated;
+          r.analytics.contextData.loid_created = decodeURIComponent(loggedOutData.loidcreated);
         }
       }
     }
@@ -273,7 +273,7 @@ r.analytics = {
       params.loid = this.contextData.loid;
     }
     if (this.contextData.loid_created) {
-      params.loidcreated = this.contextData.loid_created;
+      params.loidcreated = decodeURIComponent(this.contextData.loid_created);
     }
 
     var querystring = [
@@ -333,7 +333,7 @@ r.analytics = {
       payload['user_name'] = this.contextData.user_name;
     } else {
       payload['loid'] = this.contextData.loid;
-      payload['loid_created'] = this.contextData.loid_created;
+      payload['loid_created'] = decodeURIComponent(this.contextData.loid_created);
     }
 
     properties.forEach(function(contextProperty) {


### PR DESCRIPTION
Also stop extra-quoting them on the backend. Apparently, pylons already quotes cookies on the way out, leading to some cooke being doubly escaped. Correspondingly, aggressively decode loidcreated in JS to counteract any badly-formed cookies.