### PR TITLE
VCommentIDs: remove duplicate ids

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -3561,6 +3561,7 @@ class ApiController(RedditController):
                 return abort(403,'forbidden')
 
             if children:
+                children = list(set(children))
                 builder = CommentBuilder(link, CommentSortMenu.operator(sort),
                                          children=children,
                                          num=CHILD_FETCH_COUNT)


### PR DESCRIPTION
GET_morechildren is exploding down the line if there's duplicates in the id list. The simple solution is to split via regex to account for spaces, and use `set` on it to remove duplicates.