### PR TITLE
Make the "get started with automod" go to the sr wiki page if there's…

### DIFF
--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -589,8 +589,8 @@ class Reddit(Templated):
                     css_class="reddit-flair access-required",
                     data=data_attrs('flair')))
 
-        if is_single_subreddit and is_moderator_with_perms('config'):
-            # append automod button if they have an AutoMod configuration
+        if g.automoderator_account and is_single_subreddit and is_moderator_with_perms('config'):
+            # append automod button if AutoMod is enabled and they have an AutoMod configuration
             try:
                 WikiPage.get(c.site, "config/automoderator")
                 buttons.append(NamedButton(


### PR DESCRIPTION
… no docs

The button as it stands shows up on local installs, even if automod is not enabled. The button also leads to /wiki/automoderator, even though such a page with docs doesn't necessarily exist.

This makes the button only show up if automod is enabled on the install, and if there are no docs, it sends the button to the "create config/automoderator" page instead of a 404.