### PR TITLE
Add author flair placeholders to automoderator

### DIFF
--- a/r2/r2/lib/automoderator.py
+++ b/r2/r2/lib/automoderator.py
@@ -98,6 +98,10 @@ def replace_placeholders(string, data, matches):
         "{{author}}": data["author"].name,
         "{{body}}": getattr(item, "body", ""),
         "{{subreddit}}": data["subreddit"].name,
+        "{{author_flair_text}}": data["author"].flair_text(
+            data["subreddit"]._id, obey_disabled=True),
+        "{{author_flair_css_class}}": data["author"].flair_css_class(
+            data["subreddit"]._id, obey_disabled=True),
     }
 
     if isinstance(item, Comment):


### PR DESCRIPTION
As requested and reminded [here](https://www.reddit.com/r/ModSupport/comments/4bz7xg/an_icon_for_1_day_old_accounts/d1e4f1k), adds placeholders for the author's flair css class and text.

Defaults to an empty string if the attribute is missing (they don't a flair).