### PR TITLE
install-reddit.sh: Fetch the install scripts without root.

### DIFF
--- a/install-reddit.sh
+++ b/install-reddit.sh
@@ -69,11 +69,11 @@ if [ "$MISSING" != "" ]; then
     important "We're going to grab the scripts we need and show you where you can"
     important "edit the config to suit your environment."
 
-    mkdir -p $SCRIPTDIR
+    sudo -u ${SUDO_USER} mkdir -p $SCRIPTDIR
     pushd $SCRIPTDIR > /dev/null
     for item in ${NEEDED[*]}; do
         echo "Grabbing '${item}'..."
-        wget -q $GITREPO/$item
+        sudo -u ${SUDO_USER} wget -q $GITREPO/$item
         chmod +x $item
     done
     popd > /dev/null


### PR DESCRIPTION
install-reddit.sh currently fetches the individual install scripts as root. Since the person installing reddit may be inept at linux, they may not be able to figure out how to edit these files on the chance they need to (ex editing install/install.cfg to add another plugin).

This change makes the directory be made and the files be retrieved as the user who had started the script, so they won't have an annoyance editing the retrieved files later on.
