### PR TITLE
set_api_docs: skip VNotInTimeout validators without docs

### DIFF
--- a/r2/r2/lib/validator/validator.py
+++ b/r2/r2/lib/validator/validator.py
@@ -173,6 +173,8 @@ def set_api_docs(fn, simple_vals, param_vals, extra_vals=None):
         param_docs = validator.param_docs()
         if validator.docs:
             param_docs.update(validator.docs)
+        elif isinstance(validator, VNotInTimeout):
+            continue
         param_info.update(param_docs)
         if validator.notes:
             notes.append(validator.notes)


### PR DESCRIPTION
VNotInTimeout is causing the details of some parameters to be wiped, such as the details of [id in POST_set_subreddit_sticky](https://www.reddit.com/dev/api#POST_api_set_subreddit_sticky), because by default validator docs are `{param: None for param in self.param}`. If VNotInTimeout is being called within the `@validate` or `@validatedForm` decorators, and is being called with a parameter (ex 'id'), the docs for that parameter get replaced with `None`.

This solves the issue by skipping VNotInTimeOut if there are no specified docs.
