### PR TITLE
Remove unused, invalid and nonsensual attribute

### DIFF
--- a/r2/r2/templates/redditfooter.html
+++ b/r2/r2/templates/redditfooter.html
@@ -27,7 +27,7 @@
 <%namespace file="utils.html" import="text_with_links"/>
 
 <div class="footer-parent">
-  <div by-zero class="footer rounded">
+  <div class="footer rounded">
       %for toolbar in thing.nav:
       <div class="col">
         ${toolbar}


### PR DESCRIPTION
\<div class="footer rounded"> have "by-zero" attribute. This is its only occurrence in the Reddit code, so it doesn't seem to serve any purpose, nor it is valid. It was added with commit "[oh god how did this get here I am not good with computer](https://github.com/reddit/reddit/commit/e175e5e1321e30edf69bddec1a898e62ad899fb2)".