### PR TITLE
align with setup.py for httpagentparser

### DIFF
--- a/install/install_apt.sh
+++ b/install/install_apt.sh
@@ -93,6 +93,7 @@ python-tinycss2
 python-unidecode
 python-mock
 python-yaml
+python-httpagentparser
 
 python-baseplate
 


### PR DESCRIPTION
httpagentparser was added to setup.py in commit b9fcc7c556f22f47a264d8cf09e59f2768a31a34. Fresh install had errors missing this package. Include the Ubuntu package

👓  @KeyserSosa @kjoconnor 
