### PR TITLE
Fix compiled CSS to cope with parent-relative paths

### DIFF
--- a/r2/Makefile
+++ b/r2/Makefile
@@ -96,6 +96,7 @@ STATIC_FILES := $(shell find $(STATIC_ROOT) -readable)
 STATIC_BUILD_ROOT := $(BUILD_DIR)/public
 STATIC_BUILD_DIR := $(STATIC_BUILD_ROOT)/static
 STATIC_BUILDSTAMP := $(BUILD_DIR)/static-buildstamp
+CSS_DEST_DIR := $(STATIC_BUILD_DIR)/compiled-css
 
 .PHONY: clean_static
 
@@ -106,6 +107,7 @@ clean_static:
 
 $(STATIC_BUILDSTAMP): $(STATIC_FILES)
 	cp -ruTL $(STATIC_ROOT) $(STATIC_BUILD_ROOT)
+	test -d $(CSS_DEST_DIR) || mkdir $(CSS_DEST_DIR)
 	touch $@
 
 #################### Plugin static files
@@ -131,12 +133,12 @@ LESSC := lessc
 CSS_COMPRESS := $(PYTHON) r2/lib/contrib/rcssmin.py
 CSS_SOURCE_DIR := $(STATIC_BUILD_DIR)/css
 
-PROCESSED_SPRITED_STYLESHEETS := $(addprefix $(STATIC_BUILD_DIR)/, $(SPRITED_STYLESHEETS:.less=.css))
-SPRITES := $(addprefix $(STATIC_BUILD_DIR)/, $(patsubst %.css,sprite-%.png, $(SPRITED_STYLESHEETS:.less=.css)))
+PROCESSED_SPRITED_STYLESHEETS := $(addprefix $(CSS_DEST_DIR)/, $(SPRITED_STYLESHEETS:.less=.css))
+SPRITES := $(addprefix $(CSS_DEST_DIR)/, $(patsubst %.css,sprite-%.png, $(SPRITED_STYLESHEETS:.less=.css)))
 
-LESS_OUTPUTS := $(addprefix $(STATIC_BUILD_DIR)/, $(patsubst %.less,%.css, $(LESS_STYLESHEETS)))
+LESS_OUTPUTS := $(addprefix $(CSS_DEST_DIR)/, $(patsubst %.less,%.css, $(LESS_STYLESHEETS)))
 
-MINIFIED_OTHER_STYLESHEETS := $(addprefix $(STATIC_BUILD_DIR)/, $(OTHER_STYLESHEETS))
+MINIFIED_OTHER_STYLESHEETS := $(addprefix $(CSS_DEST_DIR)/, $(OTHER_STYLESHEETS))
 
 PROCESSED_STYLESHEETS := $(PROCESSED_SPRITED_STYLESHEETS) $(MINIFIED_OTHER_STYLESHEETS) $(LESS_OUTPUTS)
 
@@ -148,31 +150,31 @@ css: $(STATIC_BUILDSTAMP) $(CSS_OUTPUTS)
 
 
 # the LESSC invocation is separated so the recipe fails in case of LESS errors.
-$(LESS_OUTPUTS): $(STATIC_BUILD_DIR)/%.css : $(CSS_SOURCE_DIR)/%.less
+$(LESS_OUTPUTS): $(CSS_DEST_DIR)/%.css : $(CSS_SOURCE_DIR)/%.less
 	rm -f $@
 	$(LESSC) $< > $@.tmp
 	$(CSS_COMPRESS) < $@.tmp > $@
 	rm $@.tmp
 
-$(MINIFIED_OTHER_STYLESHEETS): $(STATIC_BUILD_DIR)/%.css: $(CSS_SOURCE_DIR)/%.css
+$(MINIFIED_OTHER_STYLESHEETS): $(CSS_DEST_DIR)/%.css: $(CSS_SOURCE_DIR)/%.css
 	# when static file names are mangled, the original becomes a symlink to the mangled name
 	# remove the original file here in case it's a symlink so we don't just rewrite the old file
 	rm -f $@
 	$(CAT) $< | $(CSS_COMPRESS) > $@
 
-$(STATIC_BUILD_DIR)/sprite-%.png $(STATIC_BUILD_DIR)/%.css: $(CSS_SOURCE_DIR)/%.less $(STATIC_BUILDSTAMP)
+$(CSS_DEST_DIR)/sprite-%.png $(CSS_DEST_DIR)/%.css: $(CSS_SOURCE_DIR)/%.less $(STATIC_BUILDSTAMP)
 	# see above
-	rm -f $(STATIC_BUILD_DIR)/sprite-$*.png $(STATIC_BUILD_DIR)/$*.css
-	$(PYTHON) r2/lib/nymph.py $(CSS_SOURCE_DIR)/$*.less $(STATIC_BUILD_DIR)/sprite-$*.png > $(CSS_SOURCE_DIR)/$*.less.tmp
-	$(LESSC) $(CSS_SOURCE_DIR)/$*.less.tmp > $(STATIC_BUILD_DIR)/$*.css.tmp
-	$(CSS_COMPRESS) < $(STATIC_BUILD_DIR)/$*.css.tmp > $(STATIC_BUILD_DIR)/$*.css
-	rm $(CSS_SOURCE_DIR)/$*.less.tmp $(STATIC_BUILD_DIR)/$*.css.tmp
+	rm -f $(CSS_DEST_DIR)/sprite-$*.png $(CSS_DEST_DIR)/$*.css
+	$(PYTHON) r2/lib/nymph.py $(CSS_SOURCE_DIR)/$*.less $(CSS_DEST_DIR)/sprite-$*.png > $(CSS_SOURCE_DIR)/$*.less.tmp
+	$(LESSC) $(CSS_SOURCE_DIR)/$*.less.tmp > $(CSS_DEST_DIR)/$*.css.tmp
+	$(CSS_COMPRESS) < $(CSS_DEST_DIR)/$*.css.tmp > $(CSS_DEST_DIR)/$*.css
+	rm $(CSS_SOURCE_DIR)/$*.less.tmp $(CSS_DEST_DIR)/$*.css.tmp
 
 # deprecated; remove once compact.scss has been converted to LESS
-$(STATIC_BUILD_DIR)/sprite-%.png $(STATIC_BUILD_DIR)/%.css: $(CSS_SOURCE_DIR)/%.css $(STATIC_BUILDSTAMP)
+$(CSS_DEST_DIR)/sprite-%.png $(CSS_DEST_DIR)/%.css: $(CSS_SOURCE_DIR)/%.css $(STATIC_BUILDSTAMP)
 	# see above
-	rm -f $(STATIC_BUILD_DIR)/sprite-$*.png $(STATIC_BUILD_DIR)/$*.css
-	$(PYTHON) r2/lib/nymph.py $< $(STATIC_BUILD_DIR)/sprite-$*.png | $(CSS_COMPRESS) > $(STATIC_BUILD_DIR)/$*.css
+	rm -f $(CSS_DEST_DIR)/sprite-$*.png $(CSS_DEST_DIR)/$*.css
+	$(PYTHON) r2/lib/nymph.py $< $(CSS_DEST_DIR)/sprite-$*.png | $(CSS_COMPRESS) > $(CSS_DEST_DIR)/$*.css
 
 clean_css:
 	rm -f $(CSS_OUTPUTS)

--- a/r2/r2/lib/static.py
+++ b/r2/r2/lib/static.py
@@ -74,10 +74,12 @@ def update_static_names(names_file, files):
     base = os.path.dirname(names_file)
     for path in files:
         name = os.path.relpath(path, base)
+        basename = os.path.basename(name)
         mangled_name = generate_static_name(name, base)
-        names[name] = mangled_name
+        names[basename] = mangled_name
 
         if not os.path.islink(path):
+            mangled_basename = os.path.basename(mangled_name)
             mangled_path = os.path.join(base, mangled_name)
             shutil.move(path, mangled_path)
             # When on NFS, cp has a bad habit of turning our symlinks into
@@ -85,7 +87,7 @@ def update_static_names(names_file, files):
             # the case of hardlinks to the same inode.
             if os.path.exists(path):
                 os.unlink(path)
-            os.symlink(mangled_name, path)
+            os.symlink(mangled_basename, path)
 
     json_enc = json.JSONEncoder(indent=2, sort_keys=True)
     open(names_file, "w").write(json_enc.encode(names))


### PR DESCRIPTION
Compiled (static) CSS and sprites are now written out to subdirectory `static/compiled-css/` rather than `static/` so that parent-relative `url()` references are valid when `uncompressedJS = false`.  Also patches `static.py` to cope with path elements that weren't there before.  No changes to `.less` sources are required, so functionality with `uncompressedJS = true` remains unchanged.

Without this patch, any parent-relative assets (such as `url(../sidebar-grippy-hide.png)`) return 404 or, sometimes, 500 (see [example stacktrace](http://pastebin.com/Y6LDgjNA)) when `uncompressedJS = false` because relative URLs in the sources are not adjusted to compensate for the relocated compiled stylesheet output.

Resolves #1550 which describes the problem in more detail; implements proposed solution described in [this /r/redditdev post](https://redd.it/4i6tig) (which contains yet more detail).
