### PR TITLE
Fix issue with moderator removal message

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -848,7 +848,7 @@ class ApiController(RedditController):
         # for mod removals, let the now ex-mod know (NOTE: doing this earlier
         # will make the message show up in their mod inbox, which they will
         # immediately lose access to.)
-        if new and type == 'moderator':
+        if new and type == 'moderator' and victim != c.user:
             send_mod_removal_message(container, c.user, victim)
 
         # Log this action


### PR DESCRIPTION
When a moderator removes themself, a message would still be sent ([example](https://www.reddit.com/message/messages/5n38ss)). This stops that from happening.

Perhaps a better fix would be to send a slightly different message to the subreddit if a moderator removes themself (e.g. /u/user has removed themself as a moderator of /r/subreddit).