### PR TITLE
Allow users to select a ?only type on /gilded

### DIFF
--- a/r2/r2/lib/db/queries.py
+++ b/r2/r2/lib/db/queries.py
@@ -911,8 +911,14 @@ def get_all_gilded_links():
 
 
 @merged_cached_query
-def get_all_gilded():
-    return [get_all_gilded_comments(), get_all_gilded_links()]
+def get_all_gilded(include_links=True, include_comments=True):
+    queries = []
+    
+    if include_links:
+        queries.append(get_all_gilded_links())
+    if include_comments:
+        queries.append(get_all_gilded_comments())
+    return queries
 
 
 @cached_query(SubredditQueryCache, filter_fn=filter_thing)
@@ -926,8 +932,13 @@ def get_gilded_links(sr_id):
 
 
 @merged_cached_query
-def get_gilded(sr_ids):
-    queries = [get_gilded_links, get_gilded_comments]
+def get_gilded(sr_ids, include_links=True, include_comments=True):
+    queries = []
+    
+    if include_links:
+        queries.append(get_gilded_links)
+    if include_comments:
+        queries.append(get_gilded_comments)
     return [query(sr_id)
             for sr_id, query in itertools.product(tup(sr_ids), queries)]
 
@@ -943,8 +954,13 @@ def get_gilded_user_links(user_id):
 
 
 @merged_cached_query
-def get_gilded_users(user_ids):
-    queries = [get_gilded_user_links, get_gilded_user_comments]
+def get_gilded_users(user_ids, include_links=True, include_comments=True):
+    queries = []
+    
+    if include_links:
+        queries.append(get_gilded_user_links)
+    if include_comments:
+        queries.append(get_gilded_user_comments)
     return [query(user_id)
             for user_id, query in itertools.product(tup(user_ids), queries)]
 

--- a/r2/r2/models/subreddit.py
+++ b/r2/r2/models/subreddit.py
@@ -192,9 +192,11 @@ class BaseSite(object):
         from r2.lib.db import queries
         return queries.get_sr_comments(self)
 
-    def get_gilded(self):
+    def get_gilded(self, include_links=True, include_comments=True):
         from r2.lib.db import queries
-        return queries.get_gilded(self._id)
+        return queries.get_gilded(self._id,
+                                  include_links=include_links,
+                                  include_comments=include_comments)
 
     @classmethod
     def get_modactions(cls, srs, mod=None, action=None):
@@ -1574,7 +1576,7 @@ class FakeSubreddit(BaseSite):
         from r2.lib.db import queries
         return queries.get_all_comments()
 
-    def get_gilded(self):
+    def get_gilded(self, include_links=True, include_comments=True):
         raise NotImplementedError()
 
     def spammy(self):
@@ -1629,7 +1631,7 @@ class FriendsSR(FakeSubreddit):
                for friend in friends]
         return queries.MergedCachedResults(crs)
 
-    def get_gilded(self):
+    def get_gilded(self, include_links=True, include_comments=True):
         from r2.lib.db.queries import get_gilded_users
 
         friends = c.user.friend_ids()
@@ -1637,7 +1639,8 @@ class FriendsSR(FakeSubreddit):
         if not friends:
             return []
 
-        return get_gilded_users(friends)
+        return get_gilded_users(friends, include_links=include_links,
+                                include_comments=include_comments)
 
 
 class AllSR(FakeSubreddit):
@@ -1667,9 +1670,10 @@ class AllSR(FakeSubreddit):
         from r2.lib.db import queries
         return queries.get_all_comments()
 
-    def get_gilded(self):
+    def get_gilded(self, include_links=True, include_comments=True):
         from r2.lib.db import queries
-        return queries.get_all_gilded()
+        return queries.get_all_gilded(include_links=include_links,
+                                      include_comments=include_comments)
 
     def get_reported(self, include_links=True, include_comments=True):
         from r2.lib.db import queries
@@ -1860,9 +1864,11 @@ class DefaultSR(_DefaultSR):
         results = [_get_sr_comments(sr_id) for sr_id in sr_ids]
         return merge_results(*results)
 
-    def get_gilded(self):
+    def get_gilded(self, include_links=True, include_comments=True):
         from r2.lib.db.queries import get_gilded
-        return get_gilded(Subreddit.user_subreddits(c.user))
+        return get_gilded(Subreddit.user_subreddits(c.user),
+                          include_links=include_links,
+                          include_comments=include_comments)
 
     def get_live_promos(self):
         from r2.lib import promote
@@ -1956,9 +1962,11 @@ class MultiReddit(FakeSubreddit):
         results = [_get_sr_comments(sr_id) for sr_id in self.kept_sr_ids]
         return merge_results(*results)
 
-    def get_gilded(self):
+    def get_gilded(self, include_links=True, include_comments=True):
         from r2.lib.db.queries import get_gilded
-        return get_gilded(self.kept_sr_ids)
+        return get_gilded(self.kept_sr_ids,
+                          include_links=include_links,
+                          include_comments=include_comments)
 
     def get_live_promos(self):
         from r2.lib import promote


### PR DESCRIPTION
This allows users to use the ?only parameter like they can on /about/ spamlistings to choose between gilded links, comments, or both, on /gilded. /comments/gilded remains for the sake of compatibility.
