### PR TITLE
Add missing show_media_preview and allow_images settings

### DIFF
--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -317,6 +317,8 @@ class SubredditJsonTemplate(ThingJsonTemplate):
         user_is_subscriber="is_subscriber",
         user_sr_theme_enabled="user_sr_style_enabled",
         wiki_enabled="wiki_enabled",
+        show_media_preview="show_media_preview",
+        allow_images="allow_images",
     )
 
     # subreddit *attributes* (right side of the equals)
@@ -1439,6 +1441,8 @@ class SubredditSettingsTemplate(ThingJsonTemplate):
         spam_links='site.spam_links',
         spam_selfposts='site.spam_selfposts',
         spam_comments='site.spam_comments',
+        show_media_preview='site.show_media_preview',
+        allow_images='site.allow_images',
     )
 
     def kind(self, wrapped):


### PR DESCRIPTION
We had a problem recently where the bot via PRAW was undoing 2 particular subreddit settings that the moderator has set, specifically the `expand media previews on comments pages` and `allow image uploads and links to image hosting sites` options.

Now, only the `allow image uploads and links to image hosting sites (allow_images)` option is [documented](https://www.reddit.com/dev/api/#POST_api_site_admin) but the `expand media previews on comments pages (show_media_preview)` is not which is a bit weird.

I tried looking for these options in the `/about/edit.json` route of the subreddit but to no avail. This PR is based on [a past issue](https://www.reddit.com/r/redditdev/comments/1nmwta/potential_bug_with_updating_sidebar_in_praw_or_am/) and adds those two missing options. Someone also needs to update the documentation to include the `show_media_preview` setting.
