### PR TITLE
Make mod removal message clear what user was removed

### DIFF
--- a/r2/r2/lib/system_messages.py
+++ b/r2/r2/lib/system_messages.py
@@ -112,9 +112,9 @@ def notify_user_added(rel_type, author, user, target):
 
 def send_mod_removal_message(subreddit, mod, user):
     sr_name = "/r/" + subreddit.name
-    subject = "You've been removed as a moderator from %(subreddit)s"
+    subject = "%(user)s has been removed as a moderator from %(subreddit)s"
     message = (
-        "You have been removed as a moderator from %(subreddit)s.  "
+        "%(user)s: You have been removed as a moderator from %(subreddit)s.  "
         "If you have a question regarding your removal, you can "
         "contact the moderator team for %(subreddit)s by replying to this "
         "message."

--- a/r2/r2/lib/system_messages.py
+++ b/r2/r2/lib/system_messages.py
@@ -112,6 +112,7 @@ def notify_user_added(rel_type, author, user, target):
 
 def send_mod_removal_message(subreddit, mod, user):
     sr_name = "/r/" + subreddit.name
+    u_name = "/u/" + user.name
     subject = "%(user)s has been removed as a moderator from %(subreddit)s"
     message = (
         "%(user)s: You have been removed as a moderator from %(subreddit)s.  "
@@ -119,8 +120,8 @@ def send_mod_removal_message(subreddit, mod, user):
         "contact the moderator team for %(subreddit)s by replying to this "
         "message."
     )
-    subject %= {"subreddit": sr_name}
-    message %= {"subreddit": sr_name}
+    subject %= {"subreddit": sr_name, "user": u_name}
+    message %= {"subreddit": sr_name, "user": user.name}
 
     item, inbox_rel = Message._new(
         mod, user, subject, message, request.ip,


### PR DESCRIPTION
Specify the user that was removed in the subject line (instead of `You've been removed...`, it's `{user} has been removed...`) and start the message body with `{user}: You have been been removed...` (instead of just `You have been removed`).

[Relevant reddit comment explaining reasoning for this change here](https://www.reddit.com/r/modnews/comments/4ly8br/demodding_now_messages_the_user_who_was_removed/d4d7c45):

>The way it currently is, you have to look quite closely at the to/from line in order to see who was removed (and by whom), and it's already caused a bit of confusion with people seeing the message in the modmail and thinking it was sent to them (which, I imagine, is not going to be uncommon; a lot of people might the subject "**You've been removed as a moderator of..**" and, confused/panicked, skip over the comparably smaller sized to/from section of the message).

>The phrasing of the message makes sense if you're the one **getting** it, but the removal message is also sent through modmail so everyone in the sub sees it in their modmail inbox and gets the new modmail notification. Maybe change the subject to "/u/removed_mod was removed as a moderator of /r/subreddit"? 