### PR TITLE
Prevent excess grippy repainting when scrolling

### DIFF
--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -9839,13 +9839,14 @@ body.with-listing-chooser {
             &:before {
                 content: '';
                 display: block;
-                position: absolute;
+                position: fixed;
                 width: @lc-grippy-width;
                 height: 100%;
-                background: url(../sidebar-grippy-hide.png) fixed no-repeat;
+                background: url(../sidebar-grippy-hide.png) no-repeat;
                 background-position: (@lc-width + (@lc-grippy-width - @grippy-image-width) / 2) center;
                 margin-left: (@lc-grippy-width - @grippy-image-width) / 2;
                 opacity: .5;
+                will-change: transform; // browser hint to prevent excess repainting
             }
 
             &:after {


### PR DESCRIPTION
The "grippy" selector on the left of the reddit home page currently redraws when a user scrolls. This causes excessive resource usage and can make scrolling feel less fluid, as outlined here:

https://www.reddit.com/r/bugs/comments/4pfbst/the_grippy_select_on_the_left_of_the_screen/

This change moves the "fixed" property value in the background property to the position property, and it adds the will-change property with "transform" as a browser hint to stop the excess repainting. There's some good info here:

https://dev.opera.com/articles/css-will-change-property/

It's easiest to see this change in action by using Chrome's dev tools (F12), then going to Options -> More tools -> Rendering settings -> Enable paint flashing. On many systems, the FPS meter in that same section will also highlight the performance improvement that comes from preventing the frequent redraws.

There are potentially better ways of doing this, though the will-transform property seems to hold up well for this particular use case (a "sidebar").
