### PR TITLE
Adding trial of Honeycomb.io as an analytics provider

### DIFF
--- a/r2/example.ini
+++ b/r2/example.ini
@@ -74,6 +74,8 @@ modmail_email_secret = YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5
 mailgun_api_key =
 # request signing
 request_signature_secret = YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5
+# The API key for making calls to Honeycomb
+honeycomb_writekey =
 
 [DEFAULT]
 ############################################ SITE-SPECIFIC OPTIONS
@@ -284,6 +286,14 @@ statsd_addr =
 statsd_sample_rate = 1.0
 # percentage of stats for sampling (0-100)
 stats_sample_rate = 1
+
+############################################ ANALYTICS
+# where to send analytics
+analytics_provider = null
+# configuration for the honeycomb provider
+honeycomb_dataset = reddit_trial
+honeycomb_sample_rate = 100
+
 
 ############################################ EMAIL
 # which email provider to use

--- a/r2/r2/lib/app_globals.py
+++ b/r2/r2/lib/app_globals.py
@@ -224,6 +224,7 @@ class Globals(object):
             'frequency_cap_min',
             'frequency_cap_default',
             'eu_cookie_max_attempts',
+            'honeycomb_sample_rate',
         ],
 
         ConfigValue.float: [
@@ -319,6 +320,7 @@ class Globals(object):
             'events_collector_url',
             'events_collector_test_url',
             'search_provider',
+            'honeycomb_dataset',
         ],
 
         ConfigValue.choice(ONE=CL_ONE, QUORUM=CL_QUORUM): [
@@ -573,6 +575,12 @@ class Globals(object):
             self.pkg_resources_working_set,
             "r2.provider.email",
             self.email_provider,
+        )
+        self.analytics_provider = select_provider(
+            self.config,
+            self.pkg_resources_working_set,
+            "r2.provider.analytics",
+            self.analytics_provider,
         )
         self.startup_timer.intermediate("providers")
 

--- a/r2/r2/lib/comment_tree.py
+++ b/r2/r2/lib/comment_tree.py
@@ -49,8 +49,12 @@ def add_comments(comments):
     for link_id, link_comments in comments_by_link_id.iteritems():
         link = links[link_id]
 
+        event = g.analytics_provider.new_event()
+        event.add_field("name", "comment_tree.add")
+        event.add_field("version", link.comment_tree_version)
         timer = g.stats.get_timer(
-            'comment_tree.add.%s' % link.comment_tree_version)
+            'comment_tree.add.%s' % link.comment_tree_version,
+            analytics_event=event)
         timer.start()
 
         # write scores before CommentTree because the scores must exist for all

--- a/r2/r2/lib/providers/analytics/__init__.py
+++ b/r2/r2/lib/providers/analytics/__init__.py
@@ -1,0 +1,53 @@
+class AnalyticsProvider(object):
+    """Provider for sending events to an analytics platform
+
+    """
+
+    def init(self):
+        """
+        Does overall provider initialization
+
+        No return value
+        """
+        raise NotImplementedError
+
+    def new_event(self):
+        """Creates a new event to send to the analytics provider
+
+        Returns an Event object
+        """
+        raise NotImplementedError
+
+    def close(self):
+        """Finishes sending any in-flight events to the analytics provider
+
+        No return value
+        """
+        raise NotImplementedError
+
+
+class AnalyticsEvent(object):
+    """An individual event to be sent to the analytics provider
+
+    """
+
+    def add_field(self, key, value):
+        """Adds a key/value pair to the event.
+
+        No return value
+        """
+        raise NotImplementedError
+
+    def send(self):
+        """Sends the event to the provider
+
+        No return value
+        """
+        raise NotImplementedError
+
+
+class AnalyticsSendError(Exception):
+    """SendError exception gets raised when an event fails to send to the
+    provider
+
+    """

--- a/r2/r2/lib/providers/analytics/honeycomb.py
+++ b/r2/r2/lib/providers/analytics/honeycomb.py
@@ -1,0 +1,148 @@
+'''
+honeycomb is a library to allow you to send events to Honeycomb from within
+your python application.
+
+Basic usage:
+* initialize honeycomb with your Honeycomb writekey and dataset name
+* create an event object and populate it with fields
+* send the event object
+* call honeycomb.close() when your program is finished
+
+Sending on a closed or uninitialized honeycomb will throw a HoneycombSendError
+exception.'''
+
+import datetime
+import json
+import math
+import Queue
+import random
+import requests
+import threading
+
+from pylons import app_globals as g
+
+from r2.lib.providers.analytics import AnalyticsProvider
+from r2.lib.providers.analytics import AnalyticsEvent
+from r2.lib.providers.analytics import AnalyticsSendError
+
+
+random.seed()
+
+
+class HoneycombProvider(AnalyticsProvider):
+
+    def __init__(self):
+        '''initialize honeycomb and prepare it to send events to Honeycomb
+        writekey: the authorization key for your team on Honeycomb
+        dataset: the name of the default dataset to which to write
+        sample_rate: the default sample rate
+        num_workers: the number of threads to spin up to send events'''
+
+        # hardcode some values, retrieve others from config
+        num_workers = 10
+        self.url = "https://api.hound.sh"
+        self.writekey = g.secrets["honeycomb_writekey"]
+        self.dataset = g.honeycomb_dataset
+        self.sample_rate = math.ceil(g.honeycomb_sample_rate)
+        if self.sample_rate <= 0:
+            # want positive sample rate
+            self.sample_rate = 1
+
+        # use configured values to initialize the library
+        self._xmit = Transmission(num_workers)
+
+    def new_event(self):
+        ev = HoneycombEvent(self._xmit, self.writekey, self.dataset,
+                            self.sample_rate, self.url)
+        return ev
+
+    def close(self):
+        '''wait for inflight events to be transmitted then shut down cleanly'''
+        self._xmit.close()
+        # we should error on post-close sends
+        self._xmit = None
+
+
+class HoneycombEvent(AnalyticsEvent):
+    '''An Event is a collection of fields that will be sent to Honeycomb.'''
+
+    def __init__(self, xmit, writekey, dataset, sample_rate, url):
+        # populate the event's fields
+        self.created_at = datetime.datetime.now()
+        self._xmit = xmit
+        self.writekey = writekey
+        self.dataset = dataset
+        self.url = url
+        self.sample_rate = sample_rate
+        self._data = {}
+
+    def add_field(self, name, val):
+        self._data[name] = val
+
+    def send(self):
+        '''send queues this event for transmission to Honeycomb.'''
+        if self._xmit is None:
+            # do this instead of a try below to error even when sampled
+            raise AnalyticsSendError(
+                "Tried to send on a closed or uninitialized honeycomb")
+        # we keep 1/n events when samplerate is n
+        if random.randint(1, self.sample_rate) != 1:
+            return
+        self._xmit.send(self)
+
+    def __str__(self):
+        return json.dumps(self._data)
+
+
+class Transmission(object):
+
+    def __init__(self, num_workers=10):
+        self.num_workers = num_workers
+        session = requests.Session()
+        session.headers.update({"User-Agent": "honeycomb-reddit/1.0"})
+        self.session = session
+
+        # honeycomb adds events to the pending queue for us to send
+        self.pending = Queue.Queue(maxsize=1000)
+
+        self.threads = []
+        for _ in range(self.num_workers):
+            t = threading.Thread(target=self._sender)
+            t.start()
+            self.threads.append(t)
+
+    def send(self, ev):
+        '''send accepts an event and queues it to be sent'''
+        try:
+            self.pending.put_nowait(ev)
+        except Queue.Full:
+            # just drop the overflowed events
+            pass
+
+    def _sender(self):
+        '''_sender is the control loop for each sending thread'''
+        while True:
+            ev = self.pending.get()
+            if ev is None:
+                break
+            self._send(ev)
+
+    def _send(self, ev):
+        '''_send should only be called from sender and sends an individual
+            event to Honeycomb'''
+        req = requests.Request('POST', ev.url, data=str(ev))
+        req.headers.update({
+            "X-Event-Time": ev.created_at.isoformat("T"),
+            "X-Honeycomb-Team": ev.writekey,
+            "X-Honeycomb-Dataset": ev.dataset,
+            "X-Honeycomb-SampleRate": ev.sample_rate})
+        preq = self.session.prepare_request(req)
+        self.session.send(preq)
+
+    def close(self):
+        '''call close to send all in-flight requests and shut down the
+           senders nicely'''
+        for _ in range(self.num_workers):
+            self.pending.put(None)
+        for t in self.threads:
+            t.join()

--- a/r2/r2/lib/providers/analytics/null.py
+++ b/r2/r2/lib/providers/analytics/null.py
@@ -1,0 +1,29 @@
+from r2.lib.providers.analytics import AnalyticsProvider
+from r2.lib.providers.analytics import AnalyticsEvent
+
+
+class NullAnalyticsProvider(AnalyticsProvider):
+    """Provider for sending events to an analytics platform
+
+    """
+
+    def init(self):
+        pass
+
+    def new_event(self):
+        return None
+
+    def close(self):
+        pass
+
+
+class NullAnalyticsEvent(AnalyticsEvent):
+    """An individual event to be sent to the analytics provider
+
+    """
+
+    def add_field(self, key, value):
+        pass
+
+    def send(self):
+        pass

--- a/r2/setup.py
+++ b/r2/setup.py
@@ -135,5 +135,8 @@ setup(
     [r2.provider.email]
     null = r2.lib.providers.email.null:NullEmailProvider
     mailgun = r2.lib.providers.email.mailgun:MailgunEmailProvider
+    [r2.provider.analytics]
+    null = r2.lib.providers.analytics.null:NullAnalyticsProvider
+    honeycomb = r2.lib.providers.analytics.honeycomb:HoneycombProvider
     """,
 )


### PR DESCRIPTION
We are adding Honeycomb to comment_tree as a trial to begin capturing a sample of reddit data and for reddit to evaluate Honeycomb.

We added lines to example.ini for the API key, dataset name, and sample rate for sending events to Honeycomb. The production config should mirror these changes with real values.

The integration adds a new provider named Analytics and an implementation of that provider for Honeycomb and a no-op implementation named Null. We added an optional argument to Stats.get_timer for the timer creator to elect to send the event to Honeycomb as well as statsd. We added code using analytics to comment_tree.add_comments to show how it should be used.

We didn't set up the entire reddit environment to do a comprehensive test. We'll be in touch to answer any questions.

**Note**: In order for the reddit service to perform a clean shutdown, g.analytics_provider.close() **must** be called from somewhere in the shutdown process - we're not sure where that should be. Without calling close, there will be threads running from the Honeycomb provider that will cause the shutdown process to hang. 

cc: @christineyen @kjoconnor 
