### PR TITLE
POST_site_admin: Remove captcha/ratelimit errors if editing sr settings

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -2847,8 +2847,12 @@ class ApiController(RedditController):
             form.set_error(errors.CANT_CREATE_SR, "")
             c.errors.add(errors.CANT_CREATE_SR, field="")
 
-        # only care about captcha if this is creating a subreddit
-        if not sr and form.has_errors("captcha", errors.BAD_CAPTCHA):
+        # only care about captcha/ratelimit if this is creating a subreddit
+        if sr:
+            c.errors.remove((errors.BAD_CAPTCHA, 'captcha'))
+            c.errors.remove((errors.BAD_CAPTCHA, 'iden'))
+            c.errors.remove((errors.RATELIMIT, 'ratelimit'))
+        elif form.has_errors("captcha", errors.BAD_CAPTCHA):
             return
 
         domain = kw['domain']


### PR DESCRIPTION
There are cases (albeit rare) in which editing settings cause a ratelimit error to occur, even though it does not affect anything except that it gets added to the "saved" status text, such as when editing settings quickly after creation of a subreddit. Now, the error will be preemptively removed in the case that one is editing settings.

There are also cases such as @praw-dev/praw#582 where a captcha error is returned in the json response, so now captcha errors are also to be preemptively removed in the case that one is editing settings.
