### PR TITLE
Controllers: Remove `@vary_pagecache_on_experiments` entries

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -641,7 +641,6 @@ class ApiController(RedditController):
         ))
         return handle_login(**kwargs)
 
-    @vary_pagecache_on_experiments("registration_captcha")
     @csrf_exempt
     @cross_domain(allow_credentials=True)
     @validatedForm(

--- a/r2/r2/controllers/post.py
+++ b/r2/r2/controllers/post.py
@@ -181,7 +181,6 @@ class PostController(ApiController):
 
         return self.redirect(dest)
 
-    @vary_pagecache_on_experiments("registration_captcha")
     @csrf_exempt
     @validate(dest = VDestination(default = "/"))
     def POST_reg(self, dest, *a, **kw):


### PR DESCRIPTION
On stock Ubuntu 14.04, the automated install script for Ubuntu Linux 14.04 fails with the following error:

`NameError: name 'vary_pagecache_on_experiments' is not defined`

As far as I can tell, this is because that function was removed in 6dbe772e03841041ac2c89d37fda55e02e299789 .  I've removed the lines that still referenced it and the install script now works perfectly (and also the site appears to work)