### PR TITLE
Set az_selfserve_network_id to 0 to fix installs

### DIFF
--- a/r2/example.ini
+++ b/r2/example.ini
@@ -203,7 +203,10 @@ wiki_page_stylesheets_everywhere =
 
 #### ads
 az_selfserve_priorities =
-az_selfserve_network_id =
+# adzerk network id for placements. 0 is set so the parser won't break at runtime.
+# you'll need to set this to your own adzerk network id
+# See http://help.adzerk.com/hc/en-us/articles/202533809-Request
+az_selfserve_network_id = 0
 
 #### Feature toggles
 disable_ads = false


### PR DESCRIPTION
Installing reddit off the bat is currently broken because `az_selfserve_netowork_id` is expected to be an integer.

This sets it to 0 so installing reddit would work.