### PR TITLE
Allow mods to filter items into the modqueue

### DIFF
--- a/r2/r2/controllers/front.py
+++ b/r2/r2/controllers/front.py
@@ -752,7 +752,8 @@ class FrontController(RedditController):
                     return True # anything without a verdict
                 if x._spam:
                     ban_info = getattr(x, "ban_info", {})
-                    if ban_info.get("auto", True):
+                    if (ban_info.get("auto", True) or
+                            ban_info.get("keep_in_modqueue", False)):
                         return True # spam, unless banned by a moderator
                 return False
             elif location == "unmoderated":

--- a/r2/r2/lib/automoderator.py
+++ b/r2/r2/lib/automoderator.py
@@ -1003,6 +1003,7 @@ class RuleTarget(object):
             admintools.spam(
                 item,
                 auto=keep_in_modqueue,
+                keep_in_modqueue=keep_in_modqueue,
                 moderator_banned=True,
                 banner=ACCOUNT.name,
                 train_spam=spam,
@@ -1022,6 +1023,7 @@ class RuleTarget(object):
                         self.action_reason, data, self.parent.matches)
                 else:
                     reason = "spam" if spam else "remove"
+                    reason = "filter" if keep_in_modqueue else reason
                 ModAction.create(data["subreddit"], ACCOUNT, log_action,
                     target=item, details=reason)
 

--- a/r2/r2/lib/db/queries.py
+++ b/r2/r2/lib/db/queries.py
@@ -1510,7 +1510,7 @@ def edit(thing):
         m.insert(query(thing.sr_id), [thing])
 
 
-def ban(things, filtered=True):
+def ban(things, filtered=True, keep_in_modqueue=False):
     query_cache_inserts, query_cache_deletes = _common_del_ban(things)
     by_srid = _by_srid(things, srs=False)
 
@@ -1523,7 +1523,7 @@ def ban(things, filtered=True):
             # don't add posts by banned users if subreddit prefs exclude them
             add_to_modqueue = (filtered and
                        not (item.subreddit_slow.exclude_banned_modqueue and
-                            item.author_slow._spam))
+                            item.author_slow._spam)) or keep_in_modqueue
 
             if isinstance(item, Link):
                 links.append(item)
@@ -1536,7 +1536,7 @@ def ban(things, filtered=True):
 
         if links:
             query_cache_inserts.append((get_spam_links(sr_id), links))
-            if not filtered:
+            if not (filtered or keep_in_modqueue):
                 query_cache_deletes.append(
                         (get_spam_filtered_links(sr_id), links))
                 query_cache_deletes.append(
@@ -1548,7 +1548,7 @@ def ban(things, filtered=True):
 
         if comments:
             query_cache_inserts.append((get_spam_comments(sr_id), comments))
-            if not filtered:
+            if not (filtered or keep_in_modqueue):
                 query_cache_deletes.append(
                         (get_spam_filtered_comments(sr_id), comments))
 

--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -242,13 +242,16 @@ class ThingJsonTemplate(JsonTemplate):
                 return None
             return distinguished
 
-        if attr in ["num_reports", "report_reasons", "banned_by", "banned_at",
-                    "ban_note", "autobanned", "approved_by", "approved_at"]:
+        if attr in ["num_reports", "report_reasons", "ignore_reports",
+                    "banned_by", "banned_at", "ban_note",
+                    "autobanned", "approved_by", "approved_at"]:
             if c.user_is_loggedin and thing.can_ban:
                 if attr == "num_reports":
                     return thing.reported
                 elif attr == "report_reasons":
                     return Report.get_reasons(thing)
+                elif attr == "ignore_reports":
+                    return thing.ignore_reports
 
                 ban_info = getattr(thing, "ban_info", {})
                 if attr == "banned_by":
@@ -691,6 +694,7 @@ class LinkJsonTemplate(ThingJsonTemplate):
         num_comments="num_comments",
         num_reports="num_reports",
         report_reasons="report_reasons",
+        reports_ignored="ignore_reports",
         mod_reports="mod_reports",
         user_reports="user_reports",
         over_18="over_18",
@@ -938,6 +942,7 @@ class CommentJsonTemplate(ThingTemplate):
 
         data["num_reports"] = None
         data["report_reasons"] = None
+        data["reports_ignored"] = None
         data["approved_by"] = None
         data["approved_at"] = None
         data["banned_by"] = None
@@ -947,6 +952,7 @@ class CommentJsonTemplate(ThingTemplate):
         if c.user_is_loggedin and item.can_ban:
             data["num_reports"] = item.reported
             data["report_reasons"] = Report.get_reasons(item)
+            data["reports_ignored"] = item.ignore_reports
 
             ban_info = getattr(item, "ban_info", {})
             if item._spam:

--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -242,7 +242,8 @@ class ThingJsonTemplate(JsonTemplate):
                 return None
             return distinguished
 
-        if attr in ["num_reports", "report_reasons", "banned_by", "approved_by"]:
+        if attr in ["num_reports", "report_reasons", "banned_by", "banned_at",
+                    "ban_note", "autobanned", "approved_by", "approved_at"]:
             if c.user_is_loggedin and thing.can_ban:
                 if attr == "num_reports":
                     return thing.reported
@@ -255,8 +256,28 @@ class ThingJsonTemplate(JsonTemplate):
                               if ban_info.get('moderator_banned')
                               else True)
                     return banner if thing._spam else None
+                elif attr == "ban_note":
+                    return ban_info.get("note", True) if thing._spam else None
+                elif attr == "autobanned":
+                    return ban_info.get("auto", False) if thing._spam else None
+                elif attr == "banned_at":
+                    banned_at = (ban_info.get("banned_at")
+                                 if ban_info.get("banned_at")
+                                 else True)
+                    if not isinstance(banned_at, bool):
+                        banned_at = banned_at.astimezone(pytz.UTC).timetuple()
+                        banned_at = time.mktime(banned_at) - time.timezone
+                    return banned_at if thing._spam else None
                 elif attr == "approved_by":
                     return ban_info.get("unbanner") if not thing._spam else None
+                elif attr == "approved_at":
+                    unban_at = (ban_info.get("unbanned_at")
+                                if ban_info.get("unbanned_at")
+                                else True)
+                    if not isinstance(unban_at, bool):
+                        unban_at = unban_at.astimezone(pytz.UTC).timetuple()
+                        unban_at = time.mktime(unban_at) - time.timezone
+                    return unban_at if not thing._spam else None
 
         if attr == 'admin_takedown':
             if thing.admin_takedown:
@@ -642,11 +663,15 @@ class LinkJsonTemplate(ThingJsonTemplate):
         )
     _data_attrs_ = ThingJsonTemplate.data_attrs(
         approved_by="approved_by",
+        approved_at="approved_at",
         archived="archived",
         author="author",
         author_flair_css_class="author_flair_css_class",
         author_flair_text="author_flair_text",
         banned_by="banned_by",
+        banned_at="banned_at",
+        ban_note="ban_note",
+        autobanned="autobanned",
         visited="visited",
         clicked="clicked",
         distinguished="distinguished",
@@ -911,25 +936,38 @@ class CommentJsonTemplate(ThingTemplate):
         if hasattr(item, "action_type"):
             data["action_type"] = item.action_type
 
+        data["num_reports"] = None
+        data["report_reasons"] = None
+        data["approved_by"] = None
+        data["approved_at"] = None
+        data["banned_by"] = None
+        data["banned_at"] = None
+        data["ban_note"] = None
+        data["autobanned"] = None
         if c.user_is_loggedin and item.can_ban:
             data["num_reports"] = item.reported
             data["report_reasons"] = Report.get_reasons(item)
 
             ban_info = getattr(item, "ban_info", {})
             if item._spam:
-                data["approved_by"] = None
                 if ban_info.get('moderator_banned'):
                     data["banned_by"] = ban_info.get("banner") 
                 else:
                     data["banned_by"] = True
+                data['ban_note'] = ban_info.get("note", True)
+                data['banned_at'] = True
+                if ban_info.get('banned_at'):
+                    banned_at = ban_info['banned_at'].astimezone(pytz.UTC)
+                    data['banned_at'] = (time.mktime(banned_at.timetuple())
+                                         - time.timezone)
+                data["autobanned"] = ban_info.get("auto", False)
             else:
                 data["approved_by"] = ban_info.get("unbanner")
-                data["banned_by"] = None
-        else:
-            data["num_reports"] = None
-            data["report_reasons"] = None
-            data["approved_by"] = None
-            data["banned_by"] = None
+                data["approved_at"] = True
+                if ban_info.get("unbanned_at"):
+                    unban_at = ban_info['unbanned_at'].astimezone(pytz.UTC)
+                    data["approved_at"] = (time.mktime(unban_at.timetuple())
+                                           - time.timezone)
 
         if c.user_is_loggedin and c.user.in_timeout:
             data['user_reports'] = []

--- a/r2/r2/models/admintools.py
+++ b/r2/r2/models/admintools.py
@@ -48,7 +48,7 @@ admintools_hooks = HookRegistrar()
 class AdminTools(object):
 
     def spam(self, things, auto=True, moderator_banned=False,
-             banner=None, date=None, train_spam=True, **kw):
+             banner=None, date=None, train_spam=True, keep_in_modqueue=False, **kw):
         from r2.lib.db import queries
 
         all_things = tup(things)
@@ -64,7 +64,7 @@ class AdminTools(object):
             if not t._spam and train_spam:
                 note = 'spam'
             elif not t._spam and not train_spam:
-                note = 'remove not spam'
+                note = 'filtered' if keep_in_modqueue else 'remove not spam'
             elif t._spam and not train_spam:
                 note = 'confirm spam'
             elif t._spam and train_spam:
@@ -83,6 +83,7 @@ class AdminTools(object):
             else:
                 ban_info['banner'] = banner
             ban_info.update(auto=auto,
+                            keep_in_modqueue=keep_in_modqueue,
                             moderator_banned=moderator_banned,
                             banned_at=date or datetime.now(g.tz),
                             **kw)
@@ -98,7 +99,7 @@ class AdminTools(object):
             self.author_spammer(new_things, True)
             self.set_last_sr_ban(new_things)
 
-        queries.ban(all_things, filtered=auto)
+        queries.ban(all_things, filtered=auto, keep_in_modqueue=keep_in_modqueue)
 
     def unspam(self, things, moderator_unbanned=True, unbanner=None,
                train_spam=True, insert=True):

--- a/r2/r2/models/modaction.py
+++ b/r2/r2/models/modaction.py
@@ -154,6 +154,7 @@ class ModAction(tdb_cassandra.UuidThing):
                      'confirm_spam': _('confirmed spam'),
                      'remove': _('removed not spam'),
                      'spam': _('removed spam'),
+                     'filter': _('removed (filtered into modqueue)'),
                      # removemoderator
                      'remove_self': _('removed self'),
                      # editsettings

--- a/r2/r2/public/static/js/reddit.js
+++ b/r2/r2/public/static/js/reddit.js
@@ -858,8 +858,9 @@ function big_mod_action(elem, dir) {
       };
 
       elem.siblings(".status-msg").hide();
-      if (dir == -1) {
+      if ($.inArray(dir, [-1, -3]) > -1) {
         d.spam = false;
+        d.filter = dir == -3
         $.request("remove", d, null, true);
         elem.siblings(".removed").show();
       } else if (dir == -2) {

--- a/r2/r2/templates/printablebuttons.html
+++ b/r2/r2/templates/printablebuttons.html
@@ -45,6 +45,10 @@
            ${ynbutton(_("remove"), _("removed"), "remove", hidden_data=dict(spam=False),
              event_action='remove')}
         </li>
+        <li>
+           ${ynbutton(_("filter"), _("filtered"), "remove", hidden_data=dict(spam=False, filter=True),
+             event_action='filter')}
+        </li>
       %endif
 
       %if thing.show_approve:
@@ -237,6 +241,9 @@
         %if not getattr(thing, "moderator_banned", None) or getattr(thing, "autobanned", False):
           ${pretty_button(_("spam"), "big_mod_action", -2, "negative", event_action="spam")}
           ${pretty_button(_("remove"), "big_mod_action", -1, "neutral", event_action="remove")}
+          %if not thing._spam:
+            ${pretty_button(_("filter"), "big_mod_action", -3, "neutral", event_action="filter")}
+          %endif
         %endif
 
         %if getattr(thing, "approval_checkmark", None):


### PR DESCRIPTION
This allows mods to filter items into the modqueue, just as automodertor can.
- Filtering can not be done on removed / spammed / filtered items.
- choosing 'spam' and 'filter' causes a 403
- ban info is set with a new keep_in_modqueue key, and with a 'filtered' note so mods can easily tell that an item is filtered
  - automod sets these attributes as well for consistency
- new modaction details text to reflect filtering
  - automod uses this new text as well for consistency

As asked for on /r/ModSupport repeatedly. [1](https://www.reddit.com/r/ModSupport/comments/4gkxl3/request_make_automoderators_filter_action/), [2](https://www.reddit.com/r/ModSupport/comments/3i6ere/idea_give_mods_a_filter_button/), and [3](https://www.reddit.com/r/ModSupport/comments/3egq9e/allow_regular_mods_and_other_mod_bots_to_filter/). Bonus, implements [4](https://www.reddit.com/r/ModSupport/comments/3id3us/change_the_color_of_commentsposts_that_are/) via the note change (I didn't have a proper clue as to what color is appropriate so I hoped that text based is enough)
