### PR TITLE
Flairlist.html: fix improper usage of utils.html:error_field

### DIFF
--- a/r2/r2/templates/flairlist.html
+++ b/r2/r2/templates/flairlist.html
@@ -29,7 +29,7 @@
       <input type="text" maxlength="20" id="flair_jump_name" name="name"
              value="${name}">
       <button type="submit">${_('go')}</button>
-      ${utils.error_field(('USER_DOESNT_EXIST', 'name'), 'name')}
+      ${utils.error_field('USER_DOESNT_EXIST', 'name')}
     </form>
     %if thing.user or thing.name:
         ${utils.plain_link(_('back to full list'), '/about/flair',


### PR DESCRIPTION
GET_flairlisting sets `USER_DOESNT_EXIST` error if the chosen user is nonexistent, however it's not rendering due to FlairPane checking for a `('USER_DOESNT_EXIST', 'name')` error by mistake. This commit resolves the issue.

Originally reported [here](http://www.reddit.com/r/bugs/comments/4skigo/_/d5a1u24).