### PR TITLE
Install Zookeeper on Travis

### DIFF
--- a/install/travis.sh
+++ b/install/travis.sh
@@ -109,6 +109,10 @@ if [ "$ENVIRONMENT" == "vagrant" ]; then
     $RUNDIR/setup_cassandra.sh
     # Configure RabbitMQ
     $RUNDIR/setup_rabbitmq.sh
+else
+    cat <<PACKAGES | xargs apt-get install $APTITUDE_OPTIONS
+zookeeperd
+PACKAGES
 fi
 
 ###############################################################################


### PR DESCRIPTION
The travis-ci build is failing because zookeeper isn't installed since the installation of services is skipped.

This installs zookeeper on travis so the builds will pass.