### PR TITLE
add omitscript arg to oembed endpoint

### DIFF
--- a/r2/r2/controllers/oembed.py
+++ b/r2/r2/controllers/oembed.py
@@ -50,6 +50,7 @@ POST_EMBED_TEMPLATE = """
       <a href="%(link_url)s">%(title)s</a> from
       <a href="%(subreddit_url)s">%(subreddit_name)s</a>
     </blockquote>
+    %(script)s
 """
 
 def _oembed_for(thing, **embed_options):
@@ -78,7 +79,7 @@ def _oembed_post(thing, **embed_options):
         live = 'data-card-created="{}"'.format(time)
 
     script = ''
-    if embed_options.get('omitscript') == "false":
+    if not embed_options.get('omitscript', False):
         script = format_html(SCRIPT_TEMPLATE,
                              embedly_script=EMBEDLY_SCRIPT,
                              )
@@ -100,9 +101,8 @@ def _oembed_post(thing, **embed_options):
                        title=websafe(thing.title),
                        subreddit_url=make_url_https(subreddit.path),
                        subreddit_name=subreddit.name,
+                       script=script,
                        )
-
-    html += script
 
     oembed_response = dict(_OEMBED_BASE,
                            type="rich",

--- a/r2/r2/controllers/oembed.py
+++ b/r2/r2/controllers/oembed.py
@@ -44,12 +44,12 @@ _OEMBED_BASE = {
 }
 
 EMBEDLY_SCRIPT = 'https://embed.redditmedia.com/widgets/platform.js'
+SCRIPT_TEMPLATE = '<script async src="%(embedly_script)s" charset="UTF-8"></script>'
 POST_EMBED_TEMPLATE = """
     <blockquote class="reddit-card" %(live_data_attr)s>
       <a href="%(link_url)s">%(title)s</a> from
       <a href="%(subreddit_url)s">%(subreddit_name)s</a>
     </blockquote>
-    <script async src="%(embedly_script)s" charset="UTF-8"></script>
 """
 
 def _oembed_for(thing, **embed_options):
@@ -77,6 +77,12 @@ def _oembed_post(thing, **embed_options):
         time = datetime.now(g.tz).isoformat()
         live = 'data-card-created="{}"'.format(time)
 
+    script = ''
+    if embed_options.get('omitscript') == "false":
+        script = format_html(SCRIPT_TEMPLATE,
+                             embedly_script=EMBEDLY_SCRIPT,
+                             )
+
     link_url = UrlParser(thing.make_permalink_slow(force_domain=True))
     link_url.update_query(ref='share', ref_source='embed')
 
@@ -94,8 +100,9 @@ def _oembed_post(thing, **embed_options):
                        title=websafe(thing.title),
                        subreddit_url=make_url_https(subreddit.path),
                        subreddit_name=subreddit.name,
-                       embedly_script=EMBEDLY_SCRIPT,
                        )
+
+    html += script
 
     oembed_response = dict(_OEMBED_BASE,
                            type="rich",
@@ -129,7 +136,7 @@ def _oembed_comment(thing, **embed_options):
         author_name = ""
         title = ""
 
-    html = format_html(embeds.get_inject_template(),
+    html = format_html(embeds.get_inject_template(embed_options.get('omitscript')),
                        media=g.media_domain,
                        parent="true" if embed_options.get('parent') else "false",
                        live="true" if embed_options.get('live') else "false",
@@ -163,8 +170,9 @@ class OEmbedController(MinimalController):
         url=VUrl('url'),
         parent=VBoolean("parent", default=False),
         live=VBoolean("live", default=False),
+        omitscript=VBoolean("omitscript", default=False)
     )
-    def GET_oembed(self, url, parent, live):
+    def GET_oembed(self, url, parent, live, omitscript):
         """Get the oEmbed response for a URL, if any exists.
 
         Spec: http://www.oembed.com/
@@ -181,6 +189,7 @@ class OEmbedController(MinimalController):
         embed_options = {
             "parent": parent,
             "live": live,
+            "omitscript": omitscript
         }
 
         try:

--- a/r2/r2/lib/embeds.py
+++ b/r2/r2/lib/embeds.py
@@ -27,13 +27,16 @@ _COMMENT_EMBED_TEMPLATE = (
 )
 
 
-def get_inject_template():
-    script_urls = js.src("comment-embed", absolute=True, mangle_name=False)
-    scripts = "".join('<script%s src="%s"></script>' % (
-        ' async' if len(script_urls) == 1 else '',
-        script_url
-    ) for script_url in script_urls)
-    return _COMMENT_EMBED_TEMPLATE + scripts
+def get_inject_template(omitscript=False):
+    template = _COMMENT_EMBED_TEMPLATE
+    if not omitscript:
+        script_urls = js.src("comment-embed", absolute=True, mangle_name=False)
+        scripts = "".join('<script%s src="%s"></script>' % (
+            ' async' if len(script_urls) == 1 else '',
+            script_url
+        ) for script_url in script_urls)
+        template += scripts
+    return template
 
 
 def edited_after(thing, iso_timestamp, showedits):


### PR DESCRIPTION
Per [this discussion](https://www.reddit.com/r/redditdev/comments/4stlsl/feature_request_add_omitscript_argument_to_oembed/), `omitscript` is a useful argument when dealing with oembed endpoints. This adds it for both post and comment embeds.

Please look over my code and let me know if I messed something basic up, since my python is a little rusty. Thanks!

P.S. Are there tests for the oembed endpoint? I see there are api tests for other stuff.