### PR TITLE
Add backdrop-filter and text-smoothing properties to CSS filter + @supports selector

### DIFF
--- a/r2/r2/lib/cssfilter.py
+++ b/r2/r2/lib/cssfilter.py
@@ -468,7 +468,7 @@ class StylesheetValidator(object):
 
         keyword = strip_vendor_prefix(rule.lower_at_keyword)
 
-        if keyword in ("media", "keyframes"):
+        if keyword in ("media", "keyframes", "supports"):
             rules = tinycss2.parse_rule_list(rule.content)
             rule_errors = self.validate_rule_list(rules)
         elif keyword == "page":

--- a/r2/r2/lib/cssfilter.py
+++ b/r2/r2/lib/cssfilter.py
@@ -7,7 +7,7 @@
 # Original Developer. In addition, Exhibit A has been modified to be consistent
 # with Exhibit B.
 #
-# Software distributed under the License is distributed on an "AS IS" basis,
+# Software distributed under the License is distributed on an "AS IS" basis-,
 # WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
 # the specific language governing rights and limitations under the License.
 #
@@ -84,6 +84,7 @@ SAFE_PROPERTIES = {
     "animation-play-state",
     "animation-timing-function",
     "appearance",
+    "backdrop-filter",
     "backface-visibility",
     "background",
     "background-attachment",
@@ -272,6 +273,7 @@ SAFE_PROPERTIES = {
     "text-rendering",
     "text-shadow",
     "text-size-adjust",
+    "text-smoothing",
     "text-space-collapse",
     "text-transform",
     "text-underline-position",

--- a/r2/r2/lib/cssfilter.py
+++ b/r2/r2/lib/cssfilter.py
@@ -7,7 +7,7 @@
 # Original Developer. In addition, Exhibit A has been modified to be consistent
 # with Exhibit B.
 #
-# Software distributed under the License is distributed on an "AS IS" basis-,
+# Software distributed under the License is distributed on an "AS IS" basis,
 # WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
 # the specific language governing rights and limitations under the License.
 #


### PR DESCRIPTION
When trying to push a change to one of my subreddit's stylesheet, I realized that there were a couple CSS properties missing that may come in handy.

They are:
- `text-smoothing`
- `backdrop-filter`

Now, a bit about `backdrop-filter`. It's friend `filter` was left out of Reddit intentionally due to a [XSS vulnerability in earlier versions of IE](https://github.com/reddit/reddit/pull/1058#issuecomment-76466180). But since `backdrop-filter` is relatively new, it isn't in Internet Explorer, and cannot be exploited. It is safe for use.

Also, with these comes in handy `@supports` (to detect browsers which support specified CSS properties), so I've also added that to the pull request.

Adding these properties would make stylesheets look just a bit better. :)
