### PR TITLE
Preserve search syntax between searches.

### DIFF
--- a/r2/r2/templates/searchform.html
+++ b/r2/r2/templates/searchform.html
@@ -90,6 +90,10 @@
     ${search_faq()}
   %endif
 
+  %if thing.syntax:
+    <input type="hidden" name="syntax" value="${thing.syntax}">
+  %endif
+
   %for k, v in thing.search_params.iteritems():
     <input type="hidden" name="${k}" value="${v}">
   %endfor


### PR DESCRIPTION
Search syntax reverts to the default instead of preserving from run to run since it isn't set in the form. This commit adds the syntax to the html form so syntax is preserved between searches. Originally reported [here](http://www.reddit.com/r/bugs/comments/4c3h17/_/)
