### PR TITLE
check_api_friend_oauth_scope: use dict.get instead of dict.__getitem__

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -733,7 +733,7 @@ class ApiController(RedditController):
 
     def check_api_friend_oauth_scope(self, type_):
         if c.oauth_user:
-            needed_scopes = self.api_friend_scope_map[type_]
+            needed_scopes = self.api_friend_scope_map.get(type_)
             if needed_scopes is None:
                 # OAuth2 access not allowed for this friend rel type
                 # via /api/friend


### PR DESCRIPTION
VOneOf sets c.errors for us, so the user would be informed of his invalid option and get a 400 response. However, we can't use form.has_errrors because that would disallow the "enemy" type even when using the desktop site. At the same time, if a type other than those allowed and "enemy" are sent, we get a 500 because we are using `api_friend_scope_map`'s **getitem**. Switching to it's get function gives us the 400 error we want instead of the 500, and continues to allow the "enemy" type on desktop.

I became aware of this issue ~1 hour ago while writing unittests for praw. By making a mistake, I let a request get sent with the type "nonsense" which couldn't be handled in the scope map.
