### PR TITLE
Expose a link's contest mode state in the API

### DIFF
--- a/r2/r2/lib/jsontemplates.py
+++ b/r2/r2/lib/jsontemplates.py
@@ -649,6 +649,7 @@ class LinkJsonTemplate(ThingJsonTemplate):
         banned_by="banned_by",
         visited="visited",
         clicked="clicked",
+        contest_mode="contest_mode",
         distinguished="distinguished",
         domain="domain",
         downs="downvotes",


### PR DESCRIPTION
This will allow API clients to properly design a contest mode submission without having to slowly parse through all the comments.