### PR TITLE
Fix two bugs regarding ban notes

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -1025,6 +1025,12 @@ class ApiController(RedditController):
                 return
             if ban_reason and note:
                 note = "%s: %s" % (ban_reason, note)
+                # the note can collectively be 400 chars,
+                # but only 300 are allowed everywhere else
+                if len(note) > 300:
+                    c.errors.add(errors.TOO_LONG, field="note")
+                    form.set_error(errors.TOO_LONG, "note")
+                    return
             elif ban_reason:
                 note = ban_reason
 

--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -916,7 +916,11 @@ class ApiController(RedditController):
         type=VOneOf('type', ('friend',) + _sr_friend_types),
         type_and_permissions=VPermissions('type', 'permissions'),
         note=VLength('note', 300),
-        ban_reason=VLength('ban_reason', 100),
+        ban_reason=VLength(
+            'ban_reason', 100,
+            docs={'ban_reason': ('a string no longer than 100 characters, and'
+                                 ' in combination with "note", no longer than'
+                                 ' a combined total of 298 characters')}),
         duration=VInt('duration', min=1, max=999),
         ban_message=VMarkdownLength('ban_message', max_length=1000,
             empty_error=None),

--- a/r2/r2/templates/usertableitem.html
+++ b/r2/r2/templates/usertableitem.html
@@ -100,6 +100,7 @@
     ${ynbutton(_('make permanent'), _("made permanent"), "friend",
         hidden_data = dict(type=thing.type,
                            name=thing.user.name,
-                           container=thing.container_name))}
+                           container=thing.container_name,
+                           note=getattr(thing.rel, 'note', '')))}
   %endif
 </%def>


### PR DESCRIPTION
Currently when making bans permanent the note is not persisted. This persists the note in the "make permanent" button however lets an API client still purge the note if they wish to. Originally reported [here](https://www.reddit.com/r/ModSupport/comments/4yk02f/when_a_ban_is_made_permanent_can_we_keep_the_ban/).

I also found a way in which the ban note can collectively be over 300 characters when using an API client, so I limited it.
