### PR TITLE
Fix bad JS in catch-all JS handler.

### DIFF
--- a/r2/r2/lib/js.py
+++ b/r2/r2/lib/js.py
@@ -430,7 +430,7 @@ class LocalizedModule(Module):
 _submodule = {}
 module = {}
 
-catch_errors = "try {{ {content} }} catch (err) {{ r.sendError('Error running module', '{name}', ':', err.toString()) }}"
+catch_errors = "try {{ {content} }} catch (err) {{ r.logging.sendError('Error running module', '{name}', ':', err.toString()) }}"
 
 
 _submodule["config"] = Module("_setup.js",


### PR DESCRIPTION
It's broken.

`r.sendError` isn't defined ever, but it is held in `r.logging.sendError`. This means that (as a side effect) if something IS going wrong, the error logging isn't happening, like this:

![image](https://cloud.githubusercontent.com/assets/470584/18172695/b3b80504-7023-11e6-8e8a-0e36c58795bb.png)

So I fixed it.
