### PR TITLE
Remove unnecessary subreddit name placeholder (#1628)

### DIFF
--- a/r2/r2/templates/subredditselector.html
+++ b/r2/r2/templates/subredditselector.html
@@ -30,10 +30,6 @@
     <button class="add">${_("add")}</button>
   % endif
   <ul id="sr-drop-down">
-    <li class="sr-name-row"
-        onmouseover="highlight_reddit(this)"
-        onmousedown="return sr_dropdown_mdown(this)"
-        onmouseup="sr_dropdown_mup(this)">nothin</li>
   </ul>
 </div>
 <script type="text/javascript">


### PR DESCRIPTION
When selecting a subreddit name for a new post, there is a placeholder row with the text "nothin" in it. This row is meant to be hidden, but by pressing Tab you can make it show up. After playing around with it in Inspect Element for a bit, it doesn't seem to do anything useful and removing it doesn't seem to cause any issues.
