### PR TITLE
Set meta description for subreddit listings

### DIFF
--- a/r2/r2/controllers/listingcontroller.py
+++ b/r2/r2/controllers/listingcontroller.py
@@ -365,6 +365,9 @@ class SubredditListingController(ListingController):
 
         render_params['canonical_link'] = self.canonical_link()
 
+        # Set the meta description
+        render_params['short_description'] = self._build_og_description()
+
         return render_params
 
 


### PR DESCRIPTION
The meta description for a subreddit listing is currently set to the [site's tagline](https://github.com/reddit/reddit/blob/master/r2/r2/templates/base.html#L35) (`g.short_description`). Why not set the meta description to the subreddit's `public_description`, so it matches the `og:description`?
