### PR TITLE
_system_email: Fix NameError when calling Email.handler.add_to_queue

### DIFF
--- a/r2/r2/lib/emailer.py
+++ b/r2/r2/lib/emailer.py
@@ -57,7 +57,7 @@ def _system_email(email, plaintext_body, kind, reply_to="",
 
     Email.handler.add_to_queue(user,
         email, g.domain, from_address, kind,
-        body=body, reply_to=reply_to, thing=thing,
+        body=plaintext_body, reply_to=reply_to, thing=thing,
     )
 
 def _nerds_email(body, from_name, kind):


### PR DESCRIPTION
Traceback when sending a password change email:

```
File '/home/vagrant/src/reddit/r2/r2/controllers/api.py', line 1343 in POST_update_password
  emailer.password_change_email(c.user)
File '/home/vagrant/src/reddit/r2/r2/lib/emailer.py', line 224 in password_change_email
  user=user,
File '/home/vagrant/src/reddit/r2/r2/lib/emailer.py', line 60 in _system_email
  body=body, reply_to=reply_to, thing=thing,
NameError: global name 'body' is not defined
```