### PR TITLE
Avoid layout trashing while scrolling

### DIFF
--- a/r2/r2/public/static/js/scrollupdater.js
+++ b/r2/r2/public/static/js/scrollupdater.js
@@ -32,8 +32,8 @@
         },
 
         _listen: function() {
-            var throttledUpdate = _.throttle($.proxy(this, '_updateThings'), 20)
-            $(window).on('scroll', throttledUpdate)
+            var debouncedUpdate = _.debounce($.proxy(this, '_updateThings'), 100)
+            $(window).on('scroll', debouncedUpdate)
         },
 
         _updateThings: function(ev) {


### PR DESCRIPTION
Currently when scrolling, `throttledUpdate` (see diff) will hit `TimeText.prototype._refresh` (https://github.com/reddit/reddit/blob/da549027955c28b2e99098a22c814fc2ba729e11/r2/r2/public/static/js/timetext.js#L33) every 1 s, causing the DOM to be modified when force-updating the relative timestamps.
![image](https://cloud.githubusercontent.com/assets/1748521/19276955/5e01a23a-8fd8-11e6-839d-548ac584b606.png)

Modifying the DOM as direct cause of the first `scroll` event causes the layout to be trashed while in the process of scrolling, manifesting in janking. By debouncing the event, it is possible to determine with high certainty when the scroll is completed and that it is safe to trash the layout without it impacting the user.
