### PR TITLE
Strip whitespace from usernames on flair lookup and assignment

### DIFF
--- a/r2/r2/lib/validator/validator.py
+++ b/r2/r2/lib/validator/validator.py
@@ -2736,7 +2736,7 @@ class VFlairAccount(VRequired):
 
     def _lookup(self, name, allow_deleted):
         try:
-            return Account._by_name(name, allow_deleted=allow_deleted)
+            return Account._by_name(name.strip(), allow_deleted=allow_deleted)
         except NotFound:
             return None
 


### PR DESCRIPTION
For the ease of mods copypasting a username from elsewhere, such as an excel spreadsheet, whitespace is left and then the user would not be found. This just strips whitespace from the username before looking up the account name, as done elsewhere such as in `VThrottledLogin`.
