### PR TITLE
Mention karma in CANT_CREATE_SR

### DIFF
--- a/r2/r2/lib/errors.py
+++ b/r2/r2/lib/errors.py
@@ -178,7 +178,7 @@ error_list = dict((
         ('CANT_CONVERT_TO_GOLD_ONLY', _("to convert an existing subreddit to gold only, send a message to %(admin_modmail)s") 
             % dict(admin_modmail=g.admin_message_acct)),
         ('GOLD_ONLY_SR_REQUIRED', _("this subreddit must be 'gold only' to select this")),
-        ('CANT_CREATE_SR', _("your account is too new to create a subreddit. please contact the admins to request an exemption.")),
+        ('CANT_CREATE_SR', _("your account is too new or you do not have enough karma to create a subreddit. please contact the admins to request an exemption.")),
         ('BAD_PROMO_MOBILE_OS', _("you must select at least one mobile OS to target")),
         ('BAD_PROMO_MOBILE_DEVICE', _("you must select at least one device per OS to target")),
         ('USER_MUTED', _("You have been muted from this subreddit.")),


### PR DESCRIPTION
The most common, and I really mean it, the most common post in /r/help and related subreddits is when users question why they can't make a subreddit even though they have an old account. The error that users get only mentions account age and does not mention any kind of karma requirement. It's in the /r/help FAQ, but we all know no one reads that. 

Just lightly mentioning karma could reduce the traffic on /r/help as well as be more clear.
