### PR TITLE
Use relative urls to the same (not the parent) directory in CSS

### DIFF
--- a/r2/r2/lib/nymph.py
+++ b/r2/r2/lib/nymph.py
@@ -104,7 +104,7 @@ def _load_spritable_images(css_filename):
                 continue
 
             image_filename, should_stretch, pixel_ratio = _extract_css_info(m)
-            image = Image.open(os.path.join(css_location, image_filename))
+            image = Image.open(os.path.join(css_location, '..', image_filename))
             image_hash = hashlib.md5(image.convert("RGBA").tostring()).hexdigest()
 
             if image_hash not in images:

--- a/r2/r2/public/static/css/compact.css
+++ b/r2/r2/public/static/css/compact.css
@@ -14,8 +14,8 @@ textarea { font-family: inherit; }
 #preload { position: absolute; top: -1000px; left: -1000px; }
 
 /*UI stuff*/
-.newbutton { -moz-appearance: none; -webkit-appearance: none; border: 8px solid transparent; -moz-border-image: url("../compact/border-button.png") 8 fill; -o-border-image: url("../compact/border-button.png") 8 fill; -webkit-border-image: url("../compact/border-button.png") 8 fill; border-image: url("../compact/border-button.png") 8 fill; color: white; font-family: inherit; font-size: 12px; font-weight: bold; text-decoration: none; text-shadow: 0px 1px 1px rgba(255, 255, 255, 0.1), 0px -1px 1px rgba(0, 0, 0, 0.4); background: none; }
-.newbutton:active, .newbutton:hover, .newbutton[selected], .newbutton.expanded, .newbutton.active { -moz-border-image: url("../compact/border-button-active.png") 8 fill; -o-border-image: url("../compact/border-button-active.png") 8 fill; -webkit-border-image: url("../compact/border-button-active.png") 8 fill; border-image: url("../compact/border-button-active.png") 8 fill; color: white; }
+.newbutton { -moz-appearance: none; -webkit-appearance: none; border: 8px solid transparent; -moz-border-image: url("./compact/border-button.png") 8 fill; -o-border-image: url("./compact/border-button.png") 8 fill; -webkit-border-image: url("./compact/border-button.png") 8 fill; border-image: url("./compact/border-button.png") 8 fill; color: white; font-family: inherit; font-size: 12px; font-weight: bold; text-decoration: none; text-shadow: 0px 1px 1px rgba(255, 255, 255, 0.1), 0px -1px 1px rgba(0, 0, 0, 0.4); background: none; }
+.newbutton:active, .newbutton:hover, .newbutton[selected], .newbutton.expanded, .newbutton.active { -moz-border-image: url("./compact/border-button-active.png") 8 fill; -o-border-image: url("./compact/border-button-active.png") 8 fill; -webkit-border-image: url("./compact/border-button-active.png") 8 fill; border-image: url("./compact/border-button-active.png") 8 fill; color: white; }
 
 .button, .button:visited { -moz-border-radius: 6px; -webkit-border-radius: 6px; border-radius: 6px; background: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2JmZDBlMCIvPjxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzgwYTJjNCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA=='); background: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #bfd0e0), color-stop(100%, #80a2c4)); background: -moz-linear-gradient(top, #bfd0e0, #80a2c4); background: -webkit-linear-gradient(top, #bfd0e0, #80a2c4); background: linear-gradient(to bottom, #bfd0e0, #80a2c4); background-color: #9fb9d2; height: 30px; line-height: 30px; color: white; font-family: inherit; font-size: 12px; font-weight: bold; margin: 0px; padding: 5px; text-decoration: none; text-overflow: ellipsis; white-space: nowrap; width: auto; text-shadow: 0px 1px 1px rgba(255, 255, 255, 0.1), 0px -1px 1px rgba(0, 0, 0, 0.4); border: 1px solid #517191; -moz-box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.75), 0px 1px 1px rgba(255, 255, 255, 0.6), 0px -1px 1px rgba(0, 0, 0, 0.1); -webkit-box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.75), 0px 1px 1px rgba(255, 255, 255, 0.6), 0px -1px 1px rgba(0, 0, 0, 0.1); box-shadow: inset 0px 1px 0px rgba(255, 255, 255, 0.75), 0px 1px 1px rgba(255, 255, 255, 0.6), 0px -1px 1px rgba(0, 0, 0, 0.1); }
 
@@ -38,8 +38,8 @@ button.button { padding: 0 5px; }
 .group_button:last-child { -webkit-border-top-left-radius: 0px; -moz-border-radius-topleft: 0px; -webkit-border-bottom-left-radius: 0px; -moz-border-radius-bottomleft: 0px; -webkit-border-top-right-radius: 6px; -moz-border-radius-topright: 6px; -webkit-border-bottom-right-radius: 6px; -moz-border-radius-bottomright: 6px; border-right: 1px solid #517090; }
 
 /*Options popups*/
-.options_link { font-size: x-small; clear: left; margin: 2px 0px 0px 10px; display: inline-block; width: 30px; height: 30px; position: absolute; top: 35px; right: 10px; background-image: url("../compact/options.png"); /*SPRITE*/ }
-.options_link.active { background-image: url("../compact/options-active.png"); /*SPRITE*/ }
+.options_link { font-size: x-small; clear: left; margin: 2px 0px 0px 10px; display: inline-block; width: 30px; height: 30px; position: absolute; top: 35px; right: 10px; background-image: url("./compact/options.png"); /*SPRITE*/ }
+.options_link.active { background-image: url("./compact/options-active.png"); /*SPRITE*/ }
 
 .comment .options_link { top: 10px; }
 
@@ -60,33 +60,33 @@ button.button { padding: 0 5px; }
 
 .options_icons, .email-icon, .report-icon, .save-icon, .unsave-icon, .domain-icon, .edit-icon, .reply-icon, .permalink-icon, .collapse-icon, .context-icon, .parent-icon, .unread-icon, .hide-icon, .unhide-icon { display: block; width: 24px; height: 24px; margin-left: auto; margin-right: auto; margin-bottom: 5px; }
 
-.email-icon { background-image: url("../compact/email.png"); /*SPRITE*/ }
+.email-icon { background-image: url("./compact/email.png"); /*SPRITE*/ }
 
-.report-icon { background-image: url("../compact/report.png"); /*SPRITE*/ }
+.report-icon { background-image: url("./compact/report.png"); /*SPRITE*/ }
 
-.save-icon { background-image: url("../compact/save.png"); /*SPRITE*/ }
+.save-icon { background-image: url("./compact/save.png"); /*SPRITE*/ }
 
-.unsave-icon { background-image: url("../compact/unsave.png"); /*SPRITE*/ }
+.unsave-icon { background-image: url("./compact/unsave.png"); /*SPRITE*/ }
 
-.domain-icon { background-image: url("../compact/domain.png"); /*SPRITE*/ }
+.domain-icon { background-image: url("./compact/domain.png"); /*SPRITE*/ }
 
-.edit-icon { background-image: url("../compact/edit.png"); /*SPRITE*/ }
+.edit-icon { background-image: url("./compact/edit.png"); /*SPRITE*/ }
 
-.reply-icon { background-image: url("../compact/reply.png"); /*SPRITE*/ }
+.reply-icon { background-image: url("./compact/reply.png"); /*SPRITE*/ }
 
-.permalink-icon { background-image: url("../compact/permalink.png"); /*SPRITE*/ }
+.permalink-icon { background-image: url("./compact/permalink.png"); /*SPRITE*/ }
 
-.collapse-icon { background-image: url("../compact/collapse.png"); /*SPRITE*/ }
+.collapse-icon { background-image: url("./compact/collapse.png"); /*SPRITE*/ }
 
-.context-icon { background-image: url("../compact/context.png"); /*SPRITE*/ }
+.context-icon { background-image: url("./compact/context.png"); /*SPRITE*/ }
 
-.parent-icon { background-image: url("../compact/context.png"); /*SPRITE*/ }
+.parent-icon { background-image: url("./compact/context.png"); /*SPRITE*/ }
 
-.unread-icon { background-image: url("../compact/unread.png"); /*SPRITE*/ }
+.unread-icon { background-image: url("./compact/unread.png"); /*SPRITE*/ }
 
-.hide-icon { background-image: url("../compact/hide.png"); /*SPRITE*/ }
+.hide-icon { background-image: url("./compact/hide.png"); /*SPRITE*/ }
 
-.unhide-icon { background-image: url("../compact/unhide.png"); /*SPRITE*/ }
+.unhide-icon { background-image: url("./compact/unhide.png"); /*SPRITE*/ }
 
 /*Toolbar*/
 #topbar { background: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiBncmFkaWVudFVuaXRzPSJvYmplY3RCb3VuZGluZ0JveCIgeDE9IjAuNSIgeTE9IjAuMCIgeDI9IjAuNSIgeTI9IjEuMCI+PHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iI2NlZTNmOCIvPjxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iI2E4YzRlMCIvPjwvbGluZWFyR3JhZGllbnQ+PC9kZWZzPjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JhZCkiIC8+PC9zdmc+IA=='); background: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #cee3f8), color-stop(100%, #a8c4e0)); background: -moz-linear-gradient(top, #cee3f8, #a8c4e0); background: -webkit-linear-gradient(top, #cee3f8, #a8c4e0); background: linear-gradient(to bottom, #cee3f8, #a8c4e0); background-color: #bbd3ec; border-bottom: 1px solid #7599BD; border-top: 1px solid #DCEAF7; -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; padding: 0px 10px; height: 40px; position: relative; }
@@ -104,19 +104,19 @@ body[orient="landscape"] > #topbar > h1 { margin-left: -125px; width: 250px; }
 #topbar > .right > .button:first-child { margin-right: 5px; }
 
 #topbar > .right > #mail { width: 30px; height: 30px; display: inline-block; }
-#topbar > .right > #mail.nohavemail { background-image: url("../compact/nomail.png"); /*SPRITE*/ }
-#topbar > .right > #mail.nohavemail:active, #topbar > .right > #mail.nohavemail:hover { background-image: url("../compact/nomail-active.png"); /*SPRITE*/ }
-#topbar > .right > #mail.havemail { background-image: url("../compact/havemail.png"); /*SPRITE*/ }
-#topbar > .right > #mail.havemail:active, #topbar > .right > #mail.havemail:hover { background-image: url("../compact/havemail-active.png"); /*SPRITE*/ }
+#topbar > .right > #mail.nohavemail { background-image: url("./compact/nomail.png"); /*SPRITE*/ }
+#topbar > .right > #mail.nohavemail:active, #topbar > .right > #mail.nohavemail:hover { background-image: url("./compact/nomail-active.png"); /*SPRITE*/ }
+#topbar > .right > #mail.havemail { background-image: url("./compact/havemail.png"); /*SPRITE*/ }
+#topbar > .right > #mail.havemail:active, #topbar > .right > #mail.havemail:hover { background-image: url("./compact/havemail-active.png"); /*SPRITE*/ }
 
 #topbar > .right > #modmail { width: 30px; height: 30px; display: inline-block; }
-#topbar > .right > #modmail.nohavemail { background-image: url("../compact/modmail.png"); /*SPRITE*/ }
-#topbar > .right > #modmail.nohavemail:active, #topbar > .right > #modmail.nohavemail:hover { background-image: url("../compact/modmail-active.png"); /*SPRITE*/ }
-#topbar > .right > #modmail.havemail { background-image: url("../compact/newmodmail.png"); /*SPRITE*/ }
-#topbar > .right > #modmail.havemail:active, #topbar > .right > #modmail.havemail:hover { background-image: url("../compact/newmodmail-active.png"); /*SPRITE*/ }
+#topbar > .right > #modmail.nohavemail { background-image: url("./compact/modmail.png"); /*SPRITE*/ }
+#topbar > .right > #modmail.nohavemail:active, #topbar > .right > #modmail.nohavemail:hover { background-image: url("./compact/modmail-active.png"); /*SPRITE*/ }
+#topbar > .right > #modmail.havemail { background-image: url("./compact/newmodmail.png"); /*SPRITE*/ }
+#topbar > .right > #modmail.havemail:active, #topbar > .right > #modmail.havemail:hover { background-image: url("./compact/newmodmail-active.png"); /*SPRITE*/ }
 
-.topbar-options { width: 30px; height: 30px; display: inline-block; background-image: url("../compact/menu-options.png"); /*SPRITE*/ }
-.topbar-options.active, .topbar-options:hover, .topbar-options:active { background-image: url("../compact/menu-options-active.png"); /*SPRITE*/ }
+.topbar-options { width: 30px; height: 30px; display: inline-block; background-image: url("./compact/menu-options.png"); /*SPRITE*/ }
+.topbar-options.active, .topbar-options:hover, .topbar-options:active { background-image: url("./compact/menu-options-active.png"); /*SPRITE*/ }
 
 #top_menu { position: absolute; right: 5px; top: 44px; background-color: white; border: 1px solid rgba(27, 47, 94, 0.4); border-top: 0px; -webkit-border-bottom-left-radius: 10px; -moz-border-radius-bottomleft: 10px; -webkit-border-bottom-right-radius: 10px; -moz-border-radius-bottomright: 10px; border-bottom-left-radius: 10px; border-bottom-right-radius: 10px; -moz-box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.3); -webkit-box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.3); box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.3); z-index: 5; display: none; }
 
@@ -142,10 +142,10 @@ body[orient="landscape"] > #topbar > h1 { margin-left: -125px; width: 250px; }
 /*Things*/
 /*Arrows*/
 .link .arrow, .comment .arrow, .message .arrow { width: 28px; height: 28px; cursor: pointer; display: block; margin: 1px auto 0px; outline: none; }
-.link .arrow.up, .comment .arrow.up, .message .arrow.up { background-image: url("../compact/upvote.png"); /*SPRITE*/ }
-.link .arrow.down, .comment .arrow.down, .message .arrow.down { background-image: url("../compact/downvote.png"); /*SPRITE*/ }
-.link .arrow.upmod, .comment .arrow.upmod, .message .arrow.upmod { background-image: url("../compact/upvote-active.png"); /*SPRITE*/ }
-.link .arrow.downmod, .comment .arrow.downmod, .message .arrow.downmod { background-image: url("../compact/downvote-active.png"); /*SPRITE*/ }
+.link .arrow.up, .comment .arrow.up, .message .arrow.up { background-image: url("./compact/upvote.png"); /*SPRITE*/ }
+.link .arrow.down, .comment .arrow.down, .message .arrow.down { background-image: url("./compact/downvote.png"); /*SPRITE*/ }
+.link .arrow.upmod, .comment .arrow.upmod, .message .arrow.upmod { background-image: url("./compact/upvote-active.png"); /*SPRITE*/ }
+.link .arrow.downmod, .comment .arrow.downmod, .message .arrow.downmod { background-image: url("./compact/downvote-active.png"); /*SPRITE*/ }
 
 /*Links*/
 .link { min-height: 70px; border-bottom: 1px solid #999; border-top: 1px solid #ddd; padding: 5px 5px; padding-bottom: 0px; -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; background: rgba(255, 255, 255, 0.6); position: relative; overflow: hidden; }
@@ -212,8 +212,8 @@ body[orient="landscape"] > #topbar > h1 { margin-left: -125px; width: 250px; }
 .link .tagline .stickied-tagline { color: #228822; }
 
 /*Expando*/
-.link .expando-button { float: left; display: block; height: auto; line-height: inherit; margin: 3px 10px 2px 0; width: 30px; height: 30px; background-image: url("../compact/selftext.png"); /*SPRITE*/ }
-.link .expando-button.expanded { background-image: url("../compact/selftext-active.png"); /*SPRITE*/ }
+.link .expando-button { float: left; display: block; height: auto; line-height: inherit; margin: 3px 10px 2px 0; width: 30px; height: 30px; background-image: url("./compact/selftext.png"); /*SPRITE*/ }
+.link .expando-button.expanded { background-image: url("./compact/selftext-active.png"); /*SPRITE*/ }
 
 .link > .expando { clear: both; margin: 5px 0; margin-bottom: 30px; border: 1px solid #999; background: #ddd; padding: 5px; -moz-border-radius: 8px; -webkit-border-radius: 8px; border-radius: 8px; font-size: 11px; }
 
@@ -224,8 +224,8 @@ body[orient="landscape"] > #topbar > h1 { margin-left: -125px; width: 250px; }
 /* Comment count */
 .commentcount { float: right; margin: 5px; width: 45px; text-align: right; }
 
-.commentcount > .comments { border: 8px solid transparent; -moz-border-image: url("../compact/border-button.png") 8 fill; -o-border-image: url("../compact/border-button.png") 8 fill; -webkit-border-image: url("../compact/border-button.png") 8 fill; border-image: url("../compact/border-button.png") 8 fill; color: white; font-family: inherit; font-size: 12px; font-weight: bold; text-decoration: none; text-shadow: 0px 1px 1px rgba(255, 255, 255, 0.1), 0px -1px 1px rgba(0, 0, 0, 0.4); }
-.commentcount > .comments:active, .commentcount > .comments:hover, .commentcount > .comments[selected], .commentcount > .comments.preloaded { -moz-border-image: url("../compact/border-button-active.png") 8 fill; -o-border-image: url("../compact/border-button-active.png") 8 fill; -webkit-border-image: url("../compact/border-button-active.png") 8 fill; border-image: url("../compact/border-button-active.png") 8 fill; }
+.commentcount > .comments { border: 8px solid transparent; -moz-border-image: url("./compact/border-button.png") 8 fill; -o-border-image: url("./compact/border-button.png") 8 fill; -webkit-border-image: url("./compact/border-button.png") 8 fill; border-image: url("./compact/border-button.png") 8 fill; color: white; font-family: inherit; font-size: 12px; font-weight: bold; text-decoration: none; text-shadow: 0px 1px 1px rgba(255, 255, 255, 0.1), 0px -1px 1px rgba(0, 0, 0, 0.4); }
+.commentcount > .comments:active, .commentcount > .comments:hover, .commentcount > .comments[selected], .commentcount > .comments.preloaded { -moz-border-image: url("./compact/border-button-active.png") 8 fill; -o-border-image: url("./compact/border-button-active.png") 8 fill; -webkit-border-image: url("./compact/border-button-active.png") 8 fill; border-image: url("./compact/border-button-active.png") 8 fill; }
 
 /* Comment styles */
 .commentarea > h1 { color: #4c566c; font-size: 17px; margin: 10px 10px 5px; border-bottom: 1px solid rgba(0, 0, 0, 0.2); -moz-box-shadow: 0px 1px 1px rgba(255, 255, 255, 0.4); -webkit-box-shadow: 0px 1px 1px rgba(255, 255, 255, 0.4); box-shadow: 0px 1px 1px rgba(255, 255, 255, 0.4); }
@@ -292,7 +292,7 @@ body[orient="landscape"] > #topbar > h1 { margin-left: -125px; width: 250px; }
 /** gilding */
 .gilded-icon { position: relative; display: inline-block; margin: 0 0 -15px 8px; top: -8px; color: #99895F; font-size: .9em; vertical-align: middle; }
 
-.gilded-icon:before { display: inline-block; content: ''; background-image: url(../gold-coin.png); /* SPRITE */ background-repeat: no-repeat; height: 14px; width: 13px; margin-right: 2px; vertical-align: -3px; }
+.gilded-icon:before { display: inline-block; content: ''; background-image: url(./gold-coin.png); /* SPRITE */ background-repeat: no-repeat; height: 14px; width: 13px; margin-right: 2px; vertical-align: -3px; }
 
 .user-gilded > .entry .gilded-icon:before { width: 23px; }
 
@@ -386,7 +386,7 @@ body.post-under-6h-old .gilded-icon { opacity: .55; }
 
 .tagline .admin { color: #F01; }
 
-.tagline .userattrs .cakeday { display: inline-block; text-indent: -9999px; width: 11px; height: 8px; background-image: url(../cake.png); /* SPRITE */ vertical-align: middle; }
+.tagline .userattrs .cakeday { display: inline-block; text-indent: -9999px; width: 11px; height: 8px; background-image: url(./cake.png); /* SPRITE */ vertical-align: middle; }
 
 /*Loading spinner, yay CSS animation*/
 @-webkit-keyframes rotateThis { from { -webkit-transform: scale(0.75) rotate(0deg); }
@@ -395,7 +395,7 @@ body.post-under-6h-old .gilded-icon { opacity: .55; }
 
 .loading img { -webkit-animation-name: rotateThis; -webkit-animation-duration: .5s; -webkit-animation-iteration-count: infinite; -webkit-animation-timing-function: linear; }
 
-.throbber { display: none; margin: 0 2px; background: url("../compact/throbber.gif") no-repeat; width: 18px; height: 18px; }
+.throbber { display: none; margin: 0 2px; background: url("./compact/throbber.gif") no-repeat; width: 18px; height: 18px; }
 
 .working .throbber { display: inline-block; }
 

--- a/r2/r2/public/static/css/compact.scss
+++ b/r2/r2/public/static/css/compact.scss
@@ -920,7 +920,7 @@ padding: 5px;
 .gilded-icon:before {
     display: inline-block;
     content: '';
-    background-image: url(../gold-coin.png);  /* SPRITE */
+    background-image: url(./gold-coin.png);  /* SPRITE */
     background-repeat: no-repeat;
     height: 14px;
     width: 13px;
@@ -1164,7 +1164,7 @@ body.post-under-6h-old .gilded-icon {
     text-indent: -9999px;
     width: 11px;
     height: 8px;
-    background-image: url(../cake.png); /* SPRITE */
+    background-image: url(./cake.png); /* SPRITE */
     vertical-align: middle;
 }
 

--- a/r2/r2/public/static/css/components/infobar.less
+++ b/r2/r2/public/static/css/components/infobar.less
@@ -62,8 +62,8 @@
 }
 
 .locked-infobar:before {
-  @1x: url('../infobar-icon-lock.png');
-  @2x: url('../infobar-icon-lock_2x.png');
+  @1x: url('./infobar-icon-lock.png');
+  @2x: url('./infobar-icon-lock_2x.png');
   @2x-bg-size: 20px 25px;
   .hdpi-bg-image(@1x: @1x, @2x: @2x, @2x-bg-size);
 }
@@ -76,8 +76,8 @@
 
   &.with-icon:before {
     background-color: @archived-infobar-color-border;
-    @1x: url('../infobar-icon-archived.png');
-    @2x: url('../infobar-icon-archived_2x.png');
+    @1x: url('./infobar-icon-archived.png');
+    @2x: url('./infobar-icon-archived_2x.png');
     @2x-bg-size: 25px 24px;
     .hdpi-bg-image(@1x: @1x, @2x: @2x, @2x-bg-size);
   }
@@ -90,8 +90,8 @@
   border-color: @timeout-infobar-color-border;
 
   &.with-icon:before {
-    @1x: url('../infobar-icon-banhammer.png');
-    @2x: url('../infobar-icon-banhammer_2x.png');
+    @1x: url('./infobar-icon-banhammer.png');
+    @2x: url('./infobar-icon-banhammer_2x.png');
     @2x-bg-size: 20px 27px;
     .hdpi-bg-image(@1x: @1x, @2x: @2x, @2x-bg-size);   
     background-color: @timeout-infobar-color-border;

--- a/r2/r2/public/static/css/expando.less
+++ b/r2/r2/public/static/css/expando.less
@@ -6,38 +6,38 @@
     width: 20px;
 
     &.expanded {
-        background-image: url('../icon-contract.png'); /* SPRITE */
+        background-image: url('./icon-contract.png'); /* SPRITE */
     }
 
     &.expanded:hover {
-        background-image: url('../icon-contract-hover.png'); /* SPRITE */
+        background-image: url('./icon-contract-hover.png'); /* SPRITE */
     }
 
     &.collapsed {
-        background-image: url('../icon-expand.png'); /* SPRITE */
+        background-image: url('./icon-expand.png'); /* SPRITE */
     }
 
     &.collapsed:hover {
-        background-image: url('../icon-expand-hover.png'); /* SPRITE */
+        background-image: url('./icon-expand-hover.png'); /* SPRITE */
     }
 
     @media
     only screen and (min-resolution: 2dppx),
     only screen and (-webkit-min-device-pixel-ratio: 2) {
         &.expanded {
-            background-image: url(../icon-contract_2x.png); /* SPRITE pixel-ratio=2 */
+            background-image: url(./icon-contract_2x.png); /* SPRITE pixel-ratio=2 */
         }
 
         &.expanded:hover {
-            background-image: url(../icon-contract-hover_2x.png); /* SPRITE pixel-ratio=2 */
+            background-image: url(./icon-contract-hover_2x.png); /* SPRITE pixel-ratio=2 */
         }
 
         &.collapsed {
-            background-image: url(../icon-expand_2x.png); /* SPRITE pixel-ratio=2 */
+            background-image: url(./icon-expand_2x.png); /* SPRITE pixel-ratio=2 */
         }
 
         &.collapsed:hover {
-            background-image: url(../icon-expand-hover_2x.png); /* SPRITE pixel-ratio=2 */
+            background-image: url(./icon-expand-hover_2x.png); /* SPRITE pixel-ratio=2 */
         }
     }
 }

--- a/r2/r2/public/static/css/mod-action-icons.less
+++ b/r2/r2/public/static/css/mod-action-icons.less
@@ -8,44 +8,44 @@
 }
 
 .mod-action-icon-delete {
-    .hdpi-bg-image(@1x: url(../mod-action-icon-delete.png),
-                   @2x: url(../mod-action-icon-delete_2x.png),
+    .hdpi-bg-image(@1x: url(./mod-action-icon-delete.png),
+                   @2x: url(./mod-action-icon-delete_2x.png),
                    @2x-bg-size: @mod-action-icon-size);
     
     &:hover,
     .mod-action-deleting & {
-        .hdpi-bg-image(@1x: url(../mod-action-icon-delete-active.png),
-                       @2x: url(../mod-action-icon-delete-active_2x.png),
+        .hdpi-bg-image(@1x: url(./mod-action-icon-delete-active.png),
+                       @2x: url(./mod-action-icon-delete-active_2x.png),
                        @2x-bg-size: @mod-action-icon-size);
     }
 }
 
 .mod-action-icon-edit {
-    .hdpi-bg-image(@1x: url(../mod-action-icon-edit.png),
-                   @2x: url(../mod-action-icon-edit_2x.png),
+    .hdpi-bg-image(@1x: url(./mod-action-icon-edit.png),
+                   @2x: url(./mod-action-icon-edit_2x.png),
                    @2x-bg-size: @mod-action-icon-size);
 
     &:hover {
-        .hdpi-bg-image(@1x: url(../mod-action-icon-edit-active.png),
-                       @2x: url(../mod-action-icon-edit-active_2x.png),
+        .hdpi-bg-image(@1x: url(./mod-action-icon-edit-active.png),
+                       @2x: url(./mod-action-icon-edit-active_2x.png),
                        @2x-bg-size: @mod-action-icon-size);
     }
 }
 
 .mod-action-icon-add {
-    .hdpi-bg-image(@1x: url(../mod-action-icon-add.png),
-                   @2x: url(../mod-action-icon-add_2x.png),
+    .hdpi-bg-image(@1x: url(./mod-action-icon-add.png),
+                   @2x: url(./mod-action-icon-add_2x.png),
                    @2x-bg-size: @mod-action-icon-size);
 }
 
 .mod-action-icon-cancel {
-    .hdpi-bg-image(@1x: url(../mod-action-icon-cancel.png),
-                   @2x: url(../mod-action-icon-cancel_2x.png),
+    .hdpi-bg-image(@1x: url(./mod-action-icon-cancel.png),
+                   @2x: url(./mod-action-icon-cancel_2x.png),
                    @2x-bg-size: @mod-action-icon-size);
 }
 
 .mod-action-icon-confirm {
-    .hdpi-bg-image(@1x: url(../mod-action-icon-confirm.png),
-                   @2x: url(../mod-action-icon-confirm_2x.png),
+    .hdpi-bg-image(@1x: url(./mod-action-icon-confirm.png),
+                   @2x: url(./mod-action-icon-confirm_2x.png),
                    @2x-bg-size: @mod-action-icon-size);
 }

--- a/r2/r2/public/static/css/modtools.less
+++ b/r2/r2/public/static/css/modtools.less
@@ -7,7 +7,7 @@
 
 #this_is_a_hack__please_ignore {
   // lets me put this file in the SPRITED_STYLESHEETS section of the Makefile
-  background-image: url(../reddit.com.header.png); /* SPRITE */
+  background-image: url(./reddit.com.header.png); /* SPRITE */
 }
 
 .modtools-page {

--- a/r2/r2/public/static/css/reddit-embed.less
+++ b/r2/r2/public/static/css/reddit-embed.less
@@ -62,7 +62,7 @@ p {
         bottom: @snoo-padding;
         width: @snoo-width;
         height: @snoo-height;
-        .hdpi-bg-image(@1x: url(../reddit-embed-logo.png); @2x: url(../reddit-embed-logo_2x.png););
+        .hdpi-bg-image(@1x: url(./reddit-embed-logo.png); @2x: url(./reddit-embed-logo_2x.png););
         text-indent: 100%;
         white-space: nowrap;
         overflow: hidden;

--- a/r2/r2/public/static/css/reddit.less
+++ b/r2/r2/public/static/css/reddit.less
@@ -268,7 +268,7 @@ ul.flat-vert {text-align: left;}
 
 #header-img.default-header {
     text-indent: -9999px;
-    background-image: url(../reddit.com.header.png); /* SPRITE */
+    background-image: url(./reddit.com.header.png); /* SPRITE */
     height: 40px;
     width: 120px;
     display: inline-block;
@@ -305,10 +305,10 @@ ul.flat-vert {text-align: left;}
     height: 10px;
 }
 #mail.havemail {
-    background-image: url(../mail.png);  /* SPRITE */
+    background-image: url(./mail.png);  /* SPRITE */
 }
 #mail.nohavemail {
-    background-image: url(../mailgray.png);  /* SPRITE */
+    background-image: url(./mailgray.png);  /* SPRITE */
 }
 .message-count {
   background-color: #FF7500;
@@ -331,10 +331,10 @@ ul.flat-vert {text-align: left;}
     margin-bottom: -6px;
 }
 #modmail.havemail {
-    background-image: url(../modmail.png);  /* SPRITE */
+    background-image: url(./modmail.png);  /* SPRITE */
 }
 #modmail.nohavemail {
-    background-image: url(../modmailgray.png);  /* SPRITE */
+    background-image: url(./modmailgray.png);  /* SPRITE */
 }
 .user {color: gray;}
 .user .userkarma {
@@ -417,7 +417,7 @@ ul.flat-vert {text-align: left;}
 .dropdown.lightdrop .selected {
     position: relative;
     background: none no-repeat scroll center right;
-    background-image: url(../droparrowgray.gif);
+    background-image: url(./droparrowgray.gif);
     padding-right: 21px;
     text-decoration: underline;
     color: gray; 
@@ -431,7 +431,7 @@ ul.flat-vert {text-align: left;}
 .dropdown.tabdrop .selected {
     position: relative;
     background: white none no-repeat scroll center right;
-    background-image: url(../droparrowgray.gif);
+    background-image: url(./droparrowgray.gif);
     padding: 2px 21px 1px 5px;
     margin-left: 3px;
     border: 1px solid #5f99cf;
@@ -514,7 +514,7 @@ ul.flat-vert {text-align: left;}
         content: '';
         display: inline-block;
         float: left;
-        background-image: url(../icon-info.png);  /* SPRITE */
+        background-image: url(./icon-info.png);  /* SPRITE */
         width: 16px;
         height: 16px;
         margin-right: 7px;
@@ -542,7 +542,7 @@ ul.flat-vert {text-align: left;}
         border-radius: 0;
 
         &:before {
-            background-image: url(../gold-coin.png);  /* SPRITE */
+            background-image: url(./gold-coin.png);  /* SPRITE */
             width: 13px;
             height: 14px;
             margin-top: 1px;
@@ -558,7 +558,7 @@ ul.flat-vert {text-align: left;}
     border: 1px solid #c4dbf1;
 
     background: white none repeat-x scroll center left;
-    background-image: url(../gradient-button.png);  /* SPRITE stretch-x */
+    background-image: url(./gradient-button.png);  /* SPRITE stretch-x */
 
     font-size:150%;
     font-weight:bold;
@@ -570,7 +570,7 @@ ul.flat-vert {text-align: left;}
 
 .morelink:hover, .mlh {
     border-color: #879eb4;
-    background-image: url(../gradient-button-hover.png);  /* SPRITE stretch-x */
+    background-image: url(./gradient-button-hover.png);  /* SPRITE stretch-x */
 }
 
 .morelink a {
@@ -593,15 +593,15 @@ ul.flat-vert {text-align: left;}
     height: 31px;
     width: 24px;
     background: white none no-repeat scroll center left;
-    background-image: url(../gradient-nub.png);  /* SPRITE */
+    background-image: url(./gradient-nub.png);  /* SPRITE */
 }
 
 .morelink:hover .nub, .mlhn {
-    background-image: url(../gradient-nub-hover.png);  /* SPRITE */
+    background-image: url(./gradient-nub-hover.png);  /* SPRITE */
 }
 
 .disabled .morelink, .disabled .morelink:hover {
-    background-image: url(../gradient-button-gray.png);  /* SPRITE stretch-x */
+    background-image: url(./gradient-button-gray.png);  /* SPRITE stretch-x */
     border-color: #dadada;
 }
 
@@ -611,7 +611,7 @@ ul.flat-vert {text-align: left;}
 }
 
 .disabled .morelink .nub, .disabled .morelink:hover .nub {
-    background-image: url(../gradient-nub-gray.png);  /* SPRITE */
+    background-image: url(./gradient-nub-gray.png);  /* SPRITE */
 }
 
 /* raised box */
@@ -647,19 +647,19 @@ ul.flat-vert {text-align: left;}
 }
 
 .sidebox.create .spacer a {
-    background-image: url(../create-a-reddit.png);  /* SPRITE */
+    background-image: url(./create-a-reddit.png);  /* SPRITE */
     background-repeat:no-repeat;
 }
 
 .sidebox.gold .spacer a {
-    background-image: url(../reddit_gold-40.png);  /* SPRITE */
+    background-image: url(./reddit_gold-40.png);  /* SPRITE */
     background-repeat:no-repeat;
 }
 
 .sidebox.gold .morelink {
     border:none;
     background-color:transparent;
-    background-image: url(../goldmorelink.png);  
+    background-image: url(./goldmorelink.png);  
     background-position: 0 0;
     background-repeat:no-repeat;
     height:31px;
@@ -684,7 +684,7 @@ ul.flat-vert {text-align: left;}
 
 .submit.mod-override .morelink {
     a:after {
-        background-image: url("../shield.png");
+        background-image: url("./shield.png");
         content: " ";
         position: absolute;
         height: 16px;
@@ -775,16 +775,16 @@ ul.flat-vert {text-align: left;}
 }
 
 .arrow.upmod { 
-    background-image: url(../aupmod.gif);  /* SPRITE */
+    background-image: url(./aupmod.gif);  /* SPRITE */
 }
 .arrow.downmod { 
-    background-image: url(../adownmod.gif);  /* SPRITE */
+    background-image: url(./adownmod.gif);  /* SPRITE */
 }
 .arrow.up { 
-    background-image: url(../aupgray.gif);  /* SPRITE */
+    background-image: url(./aupgray.gif);  /* SPRITE */
 }
 .arrow.down { 
-    background-image: url(../adowngray.gif);  /* SPRITE */
+    background-image: url(./adowngray.gif);  /* SPRITE */
 }
 
 .midcol {
@@ -862,7 +862,7 @@ body > .content .link.compressed .midcol {
     text-indent: -9999px;
     width: 11px;
     height: 8px;
-    background-image: url(../cake.png); /* SPRITE */
+    background-image: url(./cake.png); /* SPRITE */
     vertical-align: middle;
 }
 
@@ -1051,7 +1051,7 @@ a.banned-user { color: red; }
 .media-button .option { color: red; }
 .media-button .option.active {
     background: none no-repeat scroll right center;
-    background-image: url(../reddit-button-play.png);   /* SPRITE */
+    background-image: url(./reddit-button-play.png);   /* SPRITE */
     padding-right: 15px;
     color: #336699;
 }
@@ -1144,12 +1144,12 @@ body.with-listing-chooser.explore-page #header .pagename {
         }
         .fancy-toggle-button .add {
             &:hover {
-                background-image: url(../bg-button-add.png); /* SPRITE stretch-x */
+                background-image: url(./bg-button-add.png); /* SPRITE stretch-x */
             }
         }
         .fancy-toggle-button .remove {
             &:hover {
-                background-image: url(../bg-button-remove.png); /* SPRITE stretch-x */
+                background-image: url(./bg-button-remove.png); /* SPRITE stretch-x */
             }
         }
         .subscribe-button {
@@ -1164,7 +1164,7 @@ body.with-listing-chooser.explore-page #header .pagename {
         text-indent: -9999px;
         width: 9px;
         height: 9px;
-        background-image: url(../close-small.png);  /* SPRITE */
+        background-image: url(./close-small.png);  /* SPRITE */
         background-repeat: no-repeat;
         opacity: .3;
         margin-left: 4px;
@@ -1539,11 +1539,11 @@ body.with-listing-chooser.explore-page #header .pagename {
 }
 
 .wikiaction-revisions::before {
-    background-image: url(../report.png); /* SPRITE */
+    background-image: url(./report.png); /* SPRITE */
 }
 
 .wikiaction-pages::before {
-    background-image: url(../page_white_copy.png); /* SPRITE */
+    background-image: url(./page_white_copy.png); /* SPRITE */
 }
 
 /* organic listing */
@@ -1625,10 +1625,10 @@ body.with-listing-chooser.explore-page #header .pagename {
     text-indent: 50px;
 }
 .organic-listing .nextprev .arrow.prev {
-    background-image: url(../prev_organic.png); /* SPRITE */
+    background-image: url(./prev_organic.png); /* SPRITE */
 }
 .organic-listing .nextprev .arrow.next {
-    background-image: url(../next_organic.png); /* SPRITE */
+    background-image: url(./next_organic.png); /* SPRITE */
 }
 .organic-listing .nextprev .arrow:hover {
     cursor: pointer;
@@ -1723,11 +1723,11 @@ body.with-listing-chooser.explore-page #header .pagename {
     }
 
     &.city div:before {
-        background-image: url(../map.png); /* SPRITE */
+        background-image: url(./map.png); /* SPRITE */
     }
 
     &.country div:before {
-        background-image: url(../world.png); /* SPRITE */
+        background-image: url(./world.png); /* SPRITE */
     }
 }
 
@@ -1828,7 +1828,7 @@ body.with-listing-chooser.explore-page #header .pagename {
 
 .infobar.welcome {
     display: none;
-    background: url(../welcome-lines.png) top center;
+    background: url(./welcome-lines.png) top center;
     border: 1px solid #ff8b60;
     padding: 0;
     height: 80px;
@@ -1861,7 +1861,7 @@ body.with-listing-chooser.explore-page #header .pagename {
 .infobar.welcome h2 {
     padding: 4px 14px;
     padding-left: 38px;
-    background: white url(../welcome-upvote.png) 12px center no-repeat;
+    background: white url(./welcome-upvote.png) 12px center no-repeat;
     font-size: 13px;
     color: #222;
     border-bottom: 2px solid #ff4500;
@@ -2282,7 +2282,7 @@ body.show-controversial .comment.controversial > .entry .score:after {
 textarea.gray { color: gray; }
 
 .deepthread:after {
-    background-image: url(../continue-thread.png);  /* SPRITE */
+    background-image: url(./continue-thread.png);  /* SPRITE */
     content: " ";
     display: inline-block;
     width: 25px;
@@ -2526,7 +2526,7 @@ textarea.gray { color: gray; }
 .message.gold {
     font-family: "Bitstream Charter", "Hoefler Text", "Palatino Linotype",
                  "Book Antiqua", Palatino, georgia, garamond, FreeSerif, serif;
-    background: url(../gold/tikkit-bg.png);
+    background: url(./gold/tikkit-bg.png);
     max-width: 80em;
     text-align: center;
     padding: 20px;
@@ -2638,7 +2638,7 @@ textarea.gray { color: gray; }
 
 .clippy-bubble ul {
     list-style-type: disc;
-    list-style-image: url(../clippy-bullet.png);
+    list-style-image: url(./clippy-bullet.png);
     padding-left: 15px;
 }
 
@@ -2671,10 +2671,10 @@ textarea.gray { color: gray; }
 }
 
 .fancy-toggle-button .remove { 
-    background-image: url(../bg-button-remove.png); /* SPRITE stretch-x */
+    background-image: url(./bg-button-remove.png); /* SPRITE stretch-x */
 }
 .fancy-toggle-button .add { 
-    background-image: url(../bg-button-add.png); /* SPRITE stretch-x */
+    background-image: url(./bg-button-add.png); /* SPRITE stretch-x */
 }
 .fancy-toggle-button .banned {
     background-color: #666;
@@ -2848,7 +2848,7 @@ textarea.gray { color: gray; }
 .throbber {
     display: none;
     margin: 0 2px;
-    background: url(../throbber.gif) no-repeat;
+    background: url(./throbber.gif) no-repeat;
     width: 18px;
     height: 18px;
 }
@@ -2916,7 +2916,7 @@ body.newsletter {
         display: block;
         margin-top: 15px;
         min-height: 53px;
-        background: transparent url(../upvoted-weekly-logo.svg) 0 0 no-repeat;
+        background: transparent url(./upvoted-weekly-logo.svg) 0 0 no-repeat;
         background-size: contain;
     }
 
@@ -3015,7 +3015,7 @@ body.newsletter {
     bottom: 0;
     width: 100%;
     height: 25%;
-    background: transparent url(../upvoted-arrow-bg.png);
+    background: transparent url(./upvoted-arrow-bg.png);
     z-index: -1;
 
     &:after {
@@ -3130,7 +3130,7 @@ label + #moresearchinfo {
 .searchpane {
     margin: 5px 305px 5px 0px;
     padding-left: 96px;
-    background: #E0E0E0 url(../search-large.png) 26px center no-repeat;
+    background: #E0E0E0 url(./search-large.png) 26px center no-repeat;
 } 
 
 .search-summary {
@@ -3177,7 +3177,7 @@ label + #moresearchinfo {
 
 #search input[type=submit] {
     background-color: transparent;
-    background-image: url(../search.png); /* SPRITE */
+    background-image: url(./search.png); /* SPRITE */
     background-repeat: no-repeat;
     height: 13px;
     width: 13px;
@@ -3189,7 +3189,7 @@ label + #moresearchinfo {
 }
 
 #search input[type=submit]:hover {
-    background-image: url(../search-mouseover.png); /* SPRITE */
+    background-image: url(./search-mouseover.png); /* SPRITE */
 }
 
 @media
@@ -4582,17 +4582,17 @@ form input[type=radio] {margin: 2px .5em 0 0; }
 
 .thumbnail.nsfw {
     height: 70px;
-    background-image: url(../nsfw2.png); /* SPRITE */
+    background-image: url(./nsfw2.png); /* SPRITE */
 }
 
 .thumbnail.self {
     height: 50px;
-    background-image: url(../self_default2.png); /* SPRITE */
+    background-image: url(./self_default2.png); /* SPRITE */
 }
 
 .thumbnail.default {
     height: 50px;
-    background-image: url(../noimage.png); /* SPRITE */
+    background-image: url(./noimage.png); /* SPRITE */
 }
 
 
@@ -4732,12 +4732,12 @@ ul#image-preview-list .description pre {
 }
 
 .private-feeds.instructions .feedlink.rss-link {
-    background-image: url(../rss.png);
+    background-image: url(./rss.png);
 }
 
 .private-feeds.instructions .feedlink.json-link {
     background-color: #DDDDDD;
-    background-image: url(../json.png);
+    background-image: url(./json.png);
     color: black; 
 }
 
@@ -4777,7 +4777,7 @@ ul#image-preview-list .description pre {
 
 .dropdown.srdrop .selected {
     background: none no-repeat scroll center right;
-    background-image: url(../droparrowgray.gif); 
+    background-image: url(./droparrowgray.gif); 
     display: inline-block;
     vertical-align: bottom;
     padding-right: 21px;
@@ -4878,7 +4878,7 @@ ul#image-preview-list .description pre {
 #sr-list-cover {
     position: absolute;
     background: gray none no-repeat scroll center center;
-    background-color: url(../throbber.gif); 
+    background-color: url(./throbber.gif); 
     height: 100%;
     width: 100%;
     opacity: .7;
@@ -4925,7 +4925,7 @@ ul#image-preview-list .description pre {
 
 .sr-row.sr-selected {
     background: #EFF7FF none no-repeat scroll 0px 5px;
-    background-image: url(../rightarrow.png);    /* SPRITE */
+    background-image: url(./rightarrow.png);    /* SPRITE */
 }
 
 .sr-arrow {
@@ -5121,8 +5121,8 @@ ul.tabmenu.formtab {
         left: unit(@margin-small, px);
         top: 50%;
         .transform(translateY(-50%));
-        .hdpi-bg-image(@1x: url(../mod-action-icon-confirm.png),
-                       @2x: url(../mod-action-icon-confirm_2x.png),
+        .hdpi-bg-image(@1x: url(./mod-action-icon-confirm.png),
+                       @2x: url(./mod-action-icon-confirm_2x.png),
                        @2x-bg-size: @icon-size);
     }
 }
@@ -5172,32 +5172,32 @@ ul.tabmenu.formtab {
 }
 
 .expando-button.selftext.collapsed {
-    background-image: url(../blog-collapsed.png); /* SPRITE */
+    background-image: url(./blog-collapsed.png); /* SPRITE */
 }
 .expando-button.selftext.collapsed:hover, .eb-sch {
-    background-image: url(../blog-collapsed-hover.png); /* SPRITE */
+    background-image: url(./blog-collapsed-hover.png); /* SPRITE */
 }
 .expando-button.selftext.expanded, .eb-se {
     margin-bottom: 5px;
-    background-image: url(../blog-expanded.png); /* SPRITE */
+    background-image: url(./blog-expanded.png); /* SPRITE */
 }
 .expando-button.selftext.expanded:hover, .eb-seh {
-    background-image: url(../blog-expanded-hover.png); /* SPRITE */
+    background-image: url(./blog-expanded-hover.png); /* SPRITE */
 }
 
 .expando-button.video.collapsed {
-    background-image: url(../vid-collapsed.png); /* SPRITE */
+    background-image: url(./vid-collapsed.png); /* SPRITE */
 }
 
 .expando-button.video.collapsed:hover, .eb-vch {
-    background-image: url(../vid-collapsed-hover.png); /* SPRITE */
+    background-image: url(./vid-collapsed-hover.png); /* SPRITE */
 }
 
 .expando-button.video.expanded, .eb-ve {
-    background-image: url(../vid-expanded.png); /* SPRITE */
+    background-image: url(./vid-expanded.png); /* SPRITE */
 }
 .expando-button.video.expanded:hover, .eb-veh {
-    background-image: url(../vid-expanded-hover.png); /* SPRITE */
+    background-image: url(./vid-expanded-hover.png); /* SPRITE */
 }
 
 .expando .psuedo-selftext {
@@ -5544,7 +5544,7 @@ ul.colors {
     }
 
     td.campaign-total-budget.paid {
-        background: url(../green-check.png) no-repeat scroll center right;
+        background: url(./green-check.png) no-repeat scroll center right;
     }
 }
 
@@ -7589,13 +7589,13 @@ dd { margin-left: 20px;  }
         &.remove-sr {
             width: 9px;
             height: 9px;
-            background-image: url(../close-small.png);  /* SPRITE */
+            background-image: url(./close-small.png);  /* SPRITE */
         }
 
         &.add {
             width: 15px;
             height: 15px;
-            background-image: url(../add.png);  /* SPRITE */
+            background-image: url(./add.png);  /* SPRITE */
         }
     }
 
@@ -7712,7 +7712,7 @@ dd { margin-left: 20px;  }
             opacity: 0.3;
 
             &:after {
-                background-image: url(../add.png);  /* SPRITE */
+                background-image: url(./add.png);  /* SPRITE */
                 content: "";
                 display: block;
                 height: 15px;
@@ -7889,15 +7889,15 @@ dd { margin-left: 20px;  }
 }
 
 .titlebox .leavemoderator:before, .moderator.toggle .main:before {
-    background-image: url(../shield.png); /* SPRITE */
+    background-image: url(./shield.png); /* SPRITE */
 }
 
 .moderator.accept-invite .main:before {
-    background-image: url(../addmoderator.png); /* SPRITE */
+    background-image: url(./addmoderator.png); /* SPRITE */
 }
 
 .titlebox form.leavecontributor-button:before {
-    background-image: url(../pencil.png); /* SPRITE */
+    background-image: url(./pencil.png); /* SPRITE */
 }
 
 .titlebox form.flairtoggle {
@@ -7914,68 +7914,68 @@ dd { margin-left: 20px;  }
 .icon-menu li {margin: 5px 0;}
 
 .icon-menu .reddit-edit:before {
-    background-image: url(../reddit_edit.png); /* SPRITE */
+    background-image: url(./reddit_edit.png); /* SPRITE */
 }
 .icon-menu .edit-stylesheet:before {
-    background-image: url(../css.png); /* SPRITE */
+    background-image: url(./css.png); /* SPRITE */
 }
 .icon-menu .community-rules:before {
-    background-image: url(../reddit_rules.png); /* SPRITE */
+    background-image: url(./reddit_rules.png); /* SPRITE */
 }
 .icon-menu .reddit-traffic:before {
-    background-image: url(../reddit_traffic.png); /* SPRITE */
+    background-image: url(./reddit_traffic.png); /* SPRITE */
 }
 .icon-menu .reddit-reported:before {
-    background-image: url(../reddit_reported.png); /* SPRITE */
+    background-image: url(./reddit_reported.png); /* SPRITE */
 }
 .icon-menu .reddit-spam:before {
-    background-image: url(../reddit_spam.png); /* SPRITE */
+    background-image: url(./reddit_spam.png); /* SPRITE */
 }
 .icon-menu .reddit-ban:before {
-    background-image: url(../reddit_ban.png); /* SPRITE */
+    background-image: url(./reddit_ban.png); /* SPRITE */
 }
 .icon-menu .reddit-mute:before {
-    background-image: url(../reddit_mute.png); /* SPRITE */
+    background-image: url(./reddit_mute.png); /* SPRITE */
 }
 .icon-menu .reddit-flair:before {
-    background-image: url(../reddit_flair.png); /* SPRITE */
+    background-image: url(./reddit_flair.png); /* SPRITE */
     /* Work around a centering difference between this icon and reddit_ban.png */
     margin-left: 1px;
 }
 .icon-menu .reddit-moderationlog:before {
-    background-image: url(../reddit_moderationlog.png); /* SPRITE */
+    background-image: url(./reddit_moderationlog.png); /* SPRITE */
     margin-left: 1px;
 }
 .icon-menu .reddit-unmoderated:before {
-    background-image: url(../reddit_unmoderated.png); /* SPRITE */
+    background-image: url(./reddit_unmoderated.png); /* SPRITE */
     margin-left: 1px;
 }
 .icon-menu .reddit-edited:before {
-    background-image: url(../reddit_edited.png); /* SPRITE */
+    background-image: url(./reddit_edited.png); /* SPRITE */
     margin-left: 1px;
 }
 .icon-menu .reddit-automod:before {
-    background-image: url(../reddit_automod.png); /* SPRITE */
+    background-image: url(./reddit_automod.png); /* SPRITE */
 }
 .icon-menu .reddit-moderators:before {
-    background-image: url(../shield.png); /* SPRITE */
+    background-image: url(./shield.png); /* SPRITE */
 }
 .icon-menu .moderator-mail:before {
-    background-image: url(../mailgray.png); /* SPRITE */
+    background-image: url(./mailgray.png); /* SPRITE */
     width: 15px;
     height: 10px;
     margin-top: 4px;
     margin-left: 1px;
 }
 .icon-menu .reddit-contributors:before {
-    background-image: url(../pencil.png); /* SPRITE */
+    background-image: url(./pencil.png); /* SPRITE */
 }
 .icon-menu .reddit-modqueue:before {
-    background-image: url(../reddit_modqueue.png); /* SPRITE */
+    background-image: url(./reddit_modqueue.png); /* SPRITE */
 }
 
 .users-online:before {
-    background-image: url(../online.png);  /* SPRITE */
+    background-image: url(./online.png);  /* SPRITE */
 }
 
 .notice-taken:before, .notice-available:before {
@@ -7984,11 +7984,11 @@ dd { margin-left: 20px;  }
 
 .notice-taken:before,
 .user-form .error:before {
-    background-image: url(../icon-circle-exclamation.png);  /* SPRITE */
+    background-image: url(./icon-circle-exclamation.png);  /* SPRITE */
 }
 
 .notice-available:before {
-    background-image: url(../icon-circle-check.png);  /* SPRITE */
+    background-image: url(./icon-circle-check.png);  /* SPRITE */
 }
 
 .linkinfo {
@@ -8135,27 +8135,27 @@ a.pretty-button:hover { text-decoration: none !important }
 }
 
 .pretty-button.negative {
-    background-image: url(../bg-button-negative-unpressed.png); /* SPRITE stretch-x */
+    background-image: url(./bg-button-negative-unpressed.png); /* SPRITE stretch-x */
 }
 
 .pretty-button.negative.pressed {
-    background-image: url(../bg-button-negative-pressed.png); /* SPRITE stretch-x */
+    background-image: url(./bg-button-negative-pressed.png); /* SPRITE stretch-x */
 }
 
 .pretty-button.neutral {
-    background-image: url(../bg-button-neutral-unpressed.png); /* SPRITE stretch-x */
+    background-image: url(./bg-button-neutral-unpressed.png); /* SPRITE stretch-x */
 }
 
 .pretty-button.neutral.pressed {
-    background-image: url(../bg-button-neutral-pressed.png); /* SPRITE stretch-x */
+    background-image: url(./bg-button-neutral-pressed.png); /* SPRITE stretch-x */
 }
 
 .pretty-button.positive {
-    background-image: url(../bg-button-positive-unpressed.png); /* SPRITE stretch-x */
+    background-image: url(./bg-button-positive-unpressed.png); /* SPRITE stretch-x */
 }
 
 .pretty-button.positive.pressed {
-    background-image: url(../bg-button-positive-pressed.png); /* SPRITE stretch-x */
+    background-image: url(./bg-button-positive-pressed.png); /* SPRITE stretch-x */
 }
 
 .oatmeal img { 
@@ -8230,7 +8230,7 @@ body:not(.gold) .allminus-link {
     height: 14px;
     width: 14px;
     margin: 0 6px 0 1px;
-    background-image: url(../gold-coin.png); /* SPRITE */
+    background-image: url(./gold-coin.png); /* SPRITE */
 }
 
 #per-sr-karma {
@@ -8348,7 +8348,7 @@ form#banned textarea {
     line-height: 30px;
 
     &:before {
-        background-image: url(../gold/snoo-head.png);
+        background-image: url(./gold/snoo-head.png);
         background-repeat: no-repeat;
         content: '';
         display: inline-block;
@@ -8387,7 +8387,7 @@ form#banned textarea {
 .giftgold a:before,
 .infobar.gold:before
 {
-    background-image: url(../giftgold.png); /* SPRITE */
+    background-image: url(./giftgold.png); /* SPRITE */
 }
 
 .gold-accent.comment-visits-box {
@@ -8491,7 +8491,7 @@ form#banned textarea {
     height: 13px;
     margin: 6px 4px 6px 8px;
     border: none;
-    background: url(../close.png) no-repeat;  /* SPRITE */
+    background: url(./close.png) no-repeat;  /* SPRITE */
     text-indent: -9999px;
     opacity: .25;
 }
@@ -8559,7 +8559,7 @@ form#banned textarea {
     position: relative;
 
     .snoo-head {
-      background-image: url(../gold/snoo-head.png);
+      background-image: url(./gold/snoo-head.png);
       background-repeat: no-repeat;
       position: absolute;
       top: 7px;
@@ -8697,7 +8697,7 @@ form#banned textarea {
 
 .oauth2-authorize {
     position: relative;
-    background: url(../snoo-tray.png) no-repeat;
+    background: url(./snoo-tray.png) no-repeat;
     width: 542px;
     height: 235px;
     margin: 40px auto 0;
@@ -8893,113 +8893,113 @@ form#banned textarea {
     margin-right: 5px;
 }
 .modactions.banuser {
-    background-image: url(../modactions_banuser.png); /* SPRITE */
+    background-image: url(./modactions_banuser.png); /* SPRITE */
 }
 .modactions.unbanuser {
-    background-image: url(../modactions_unbanuser.png); /* SPRITE */
+    background-image: url(./modactions_unbanuser.png); /* SPRITE */
 }
 .modactions.muteuser {
-    background-image: url(../modactions_mute.png); /* SPRITE */
+    background-image: url(./modactions_mute.png); /* SPRITE */
 }
 .modactions.unmuteuser {
-    background-image: url(../modactions_unmute.png); /* SPRITE */
+    background-image: url(./modactions_unmute.png); /* SPRITE */
 }
 .modactions.removelink {
-    background-image: url(../modactions_removelink.png); /* SPRITE */
+    background-image: url(./modactions_removelink.png); /* SPRITE */
 }
 .modactions.approvelink {
-    background-image: url(../modactions_approvelink.png); /* SPRITE */
+    background-image: url(./modactions_approvelink.png); /* SPRITE */
 }
 .modactions.removecomment {
-    background-image: url(../modactions_removecomment.png); /* SPRITE */
+    background-image: url(./modactions_removecomment.png); /* SPRITE */
 }
 .modactions.approvecomment {
-    background-image: url(../modactions_approvecomment.png); /* SPRITE */
+    background-image: url(./modactions_approvecomment.png); /* SPRITE */
 }
 .modactions.addmoderator,
 .modactions.invitemoderator,
 .modactions.acceptmoderatorinvite {
-    background-image: url(../modactions_addmoderator.png); /* SPRITE */
+    background-image: url(./modactions_addmoderator.png); /* SPRITE */
 }
 .modactions.removemoderator,
 .modactions.uninvitemoderator {
-    background-image: url(../modactions_removemoderator.png); /* SPRITE */
+    background-image: url(./modactions_removemoderator.png); /* SPRITE */
 }
 .modactions.addcontributor {
-    background-image: url(../modactions_addcontributor.png); /* SPRITE */
+    background-image: url(./modactions_addcontributor.png); /* SPRITE */
 }
 .modactions.removecontributor {
-    background-image: url(../modactions_removecontributor.png); /* SPRITE */
+    background-image: url(./modactions_removecontributor.png); /* SPRITE */
 }
 .modactions.wikipagelisted,
 .modactions.editsettings {
-    background-image: url(../modactions_editsettings.png); /* SPRITE */
+    background-image: url(./modactions_editsettings.png); /* SPRITE */
 }
 .modactions.editflair {
-    background-image: url(../modactions_editflair.png); /* SPRITE */
+    background-image: url(./modactions_editflair.png); /* SPRITE */
 }
 .modactions.distinguish {
-    background-image: url(../modactions_distinguish.png); /* SPRITE */
+    background-image: url(./modactions_distinguish.png); /* SPRITE */
 }
 .modactions.marknsfw {
-    background-image: url(../modactions_marknsfw.png); /* SPRITE */
+    background-image: url(./modactions_marknsfw.png); /* SPRITE */
 }
 .modactions.wikirevise {
-    background-image: url(../modactions_wikirevise.png); /* SPRITE */
+    background-image: url(./modactions_wikirevise.png); /* SPRITE */
 }
 .modactions.wikipermlevel {
-    background-image: url(../modactions_wikipermlevel.png); /* SPRITE */
+    background-image: url(./modactions_wikipermlevel.png); /* SPRITE */
 }
 .modactions.wikibanned {
-    background-image: url(../modactions_banuser.png); /* SPRITE */
+    background-image: url(./modactions_banuser.png); /* SPRITE */
 }
 .modactions.wikiunbanned {
-    background-image: url(../modactions_unbanuser.png); /* SPRITE */
+    background-image: url(./modactions_unbanuser.png); /* SPRITE */
 }
 .modactions.wikicontributor {
-    background-image: url(../modactions_addcontributor.png); /* SPRITE */
+    background-image: url(./modactions_addcontributor.png); /* SPRITE */
 }
 .modactions.removewikicontributor {
-    background-image: url(../modactions_removecontributor.png); /* SPRITE */
+    background-image: url(./modactions_removecontributor.png); /* SPRITE */
 }
 .modactions.ignorereports {
-    background-image: url(../modactions_mute.png); /* SPRITE */
+    background-image: url(./modactions_mute.png); /* SPRITE */
 }
 .modactions.unignorereports {
-    background-image: url(../modactions_unmute.png); /* SPRITE */
+    background-image: url(./modactions_unmute.png); /* SPRITE */
 }
 .modactions.setpermissions {
-    background-image: url(../modactions_setpermissions.png); /* SPRITE */
+    background-image: url(./modactions_setpermissions.png); /* SPRITE */
 }
 .modactions.setsuggestedsort {
-    background-image: url(../modactions_setsuggestedsort.png); /* SPRITE */
+    background-image: url(./modactions_setsuggestedsort.png); /* SPRITE */
 }
 .modactions.sticky {
-    background-image: url(../modactions_sticky.png); /* SPRITE */
+    background-image: url(./modactions_sticky.png); /* SPRITE */
 }
 .modactions.unsticky {
-    background-image: url(../modactions_unsticky.png); /* SPRITE */
+    background-image: url(./modactions_unsticky.png); /* SPRITE */
 }
 .modactions.setcontestmode {
-    background-image: url(../modactions_setcontestmode.png); /* SPRITE */
+    background-image: url(./modactions_setcontestmode.png); /* SPRITE */
 }
 .modactions.unsetcontestmode {
-    background-image: url(../modactions_unsetcontestmode.png); /* SPRITE */
+    background-image: url(./modactions_unsetcontestmode.png); /* SPRITE */
 }
 .modactions.lock {
-    background-image: url(../modactions_lock.png); /* SPRITE */
+    background-image: url(./modactions_lock.png); /* SPRITE */
 }
 .modactions.unlock {
-    background-image: url(../modactions_unlock.png); /* SPRITE */
+    background-image: url(./modactions_unlock.png); /* SPRITE */
 }
 .modactions.createrule {
-    background-image: url(../modactions_createrule.png); /* SPRITE */
+    background-image: url(./modactions_createrule.png); /* SPRITE */
 }
 .modactions.editrule {
-    background-image: url(../modactions_editrule.png); /* SPRITE */
+    background-image: url(./modactions_editrule.png); /* SPRITE */
 }
 .modactions.deleterule {
-    background-image: url(../modactions_deleterule.png); /* SPRITE */
+    background-image: url(./modactions_deleterule.png); /* SPRITE */
 }
 
 .adminpasswordform {
@@ -9035,7 +9035,7 @@ form#banned textarea {
 
 .api-help .sidebar .head {
     position: relative;
-    background: url(../xray-snoo-head.png) top center no-repeat;
+    background: url(./xray-snoo-head.png) top center no-repeat;
     height: 188px;
     margin-bottom: -78px;
     z-index: 2;
@@ -9043,14 +9043,14 @@ form#banned textarea {
 
 .api-help .sidebar .feet {
     position: relative;
-    background: url(../xray-snoo-feet.png) top center no-repeat;
+    background: url(./xray-snoo-feet.png) top center no-repeat;
     height: 75px;
     margin-top: -42px;
     z-index: 2;
 }
 
 .api-help .toc {
-    background: #181818 url(../xray-snoo-body.png) center repeat-y;
+    background: #181818 url(./xray-snoo-body.png) center repeat-y;
     border: 5px solid #959595;
     border-radius: 8px;
     padding: 15px 2em 0 2em;
@@ -9387,7 +9387,7 @@ form#banned textarea {
 
 .sr-interest-bar {
     position: relative;
-    background: #cee3f8 url(../snoo-upside-down.png) 15px top no-repeat;
+    background: #cee3f8 url(./snoo-upside-down.png) 15px top no-repeat;
     padding: 5px;
     overflow: hidden;
     border: 1px solid #336699;
@@ -9428,7 +9428,7 @@ form#banned textarea {
 }
 
 .sr-interest-bar .subscribe {
-    background-image: url(../bg-button-add.png); /* SPRITE stretch-x */
+    background-image: url(./bg-button-add.png); /* SPRITE stretch-x */
     border: 1px solid #444;
     border-radius: 3px;
     padding: 0 6px;
@@ -9622,7 +9622,7 @@ table.diff {font-size: small;}
 .gilded-icon:before {
     display: inline-block;
     content: '';
-    background-image: url(../gold-coin.png);  /* SPRITE */
+    background-image: url(./gold-coin.png);  /* SPRITE */
     background-repeat: no-repeat;
     height: 14px;
     width: 13px;
@@ -9743,14 +9743,14 @@ body.post-under-6h-old .gilded-icon {
         display: inline-block;
         vertical-align: bottom;
         text-indent: -9999px;
-        background: transparent url(../gold/goldvertisement-logo.png) top left no-repeat;
+        background: transparent url(./gold/goldvertisement-logo.png) top left no-repeat;
         width: 79px;
         height: 18px;
         margin-right: 1px;
     }
 
     p.buy-gold {
-        background: transparent url(../gold/goldvertisement-gold.png) top left no-repeat;
+        background: transparent url(./gold/goldvertisement-gold.png) top left no-repeat;
         margin-left: 13px;
         padding-left: 67px;
         min-height: 45px;
@@ -9761,7 +9761,7 @@ body.post-under-6h-old .gilded-icon {
     }
 
     p.give-gold {
-        background: transparent url(../gold/goldvertisement-gild.png) top left no-repeat;
+        background: transparent url(./gold/goldvertisement-gild.png) top left no-repeat;
         margin-left: 23px;
         padding-left: 57px;
         min-height: 39px;
@@ -9828,7 +9828,7 @@ body.post-under-6h-old .gilded-icon {
     margin-right: 10px;
     width: 119px;
     height: 33px;
-    background-image: url(../stripe.png);
+    background-image: url(./stripe.png);
 }
 
 .stripe-note div {
@@ -9989,7 +9989,7 @@ body.with-listing-chooser {
                 position: absolute;
                 width: @lc-grippy-width;
                 height: 100%;
-                background: url(../sidebar-grippy-hide.png) fixed no-repeat;
+                background: url(./sidebar-grippy-hide.png) fixed no-repeat;
                 background-position: (@lc-width + (@lc-grippy-width - @grippy-image-width) / 2) center;
                 margin-left: (@lc-grippy-width - @grippy-image-width) / 2;
                 opacity: .5;
@@ -10049,7 +10049,7 @@ body.with-listing-chooser {
                 width: @lc-grippy-width + @grippy-fudge;
 
                 &:before {
-                    background-image: url(../sidebar-grippy-show.png);
+                    background-image: url(./sidebar-grippy-show.png);
                     background-position: ((@lc-grippy-width - @grippy-image-width) / 2 + 1) center;
                     margin-left: (@lc-grippy-width - @grippy-image-width) / 2;
                     width: @lc-grippy-width;
@@ -10281,7 +10281,7 @@ body.with-listing-chooser {
         width: 16px;
         height: 16px;
         display: block;
-        background-image: url(../throbber.gif); 
+        background-image: url(./throbber.gif); 
     }
 
     h1 {
@@ -10394,7 +10394,7 @@ body.with-listing-chooser {
             display: inline-block;
             content: " ";
             margin-right: 5px;
-            background-image: url(../trending.png); /* SPRITE */
+            background-image: url(./trending.png); /* SPRITE */
             vertical-align: middle;
         }
     }
@@ -10444,7 +10444,7 @@ body.with-listing-chooser {
   width: 100%;
 
   .fancy-inner {
-    background-image: url(../gold/gold-laurel-bg.png);
+    background-image: url(./gold/gold-laurel-bg.png);
     background-position: top center;
     background-repeat: no-repeat;
     border: 1px solid #e3e2df;
@@ -10458,7 +10458,7 @@ body.with-listing-chooser {
   &:after,
   .fancy-inner:before,
   .fancy-inner:after {
-    background-image: url(../gold/endcap.png);
+    background-image: url(./gold/endcap.png);
     background-repeat: no-repeat;
     background-size: 27px 27px;
     content: '';
@@ -10594,7 +10594,7 @@ body.with-listing-chooser {
   }
 
   .gold-banner {
-    background: transparent url(../gold/reddit-golds.png) center center no-repeat;
+    background: transparent url(./gold/reddit-golds.png) center center no-repeat;
     background-size: contain;
     height: 80px;
     margin: 30px auto 20px;
@@ -10630,7 +10630,7 @@ body.with-listing-chooser {
 
   .error {
     background: transparent center left no-repeat;
-    background-image: url(../icon-circle-exclamation.png);  /* SPRITE */
+    background-image: url(./icon-circle-exclamation.png);  /* SPRITE */
     padding-left: 20px;
     white-space: nowrap;
     line-height: 1;
@@ -10771,7 +10771,7 @@ body.with-listing-chooser {
   }
 
   span.gold-snoo {
-    background: transparent url(../gold/gold-snoo.png) center center no-repeat;
+    background: transparent url(./gold/gold-snoo.png) center center no-repeat;
     background-size: 100px;
     position: absolute;
     right: 160px;
@@ -10936,13 +10936,13 @@ body.with-listing-chooser {
 .gold-page.creddits-payment {
 
   .gold-snoo {
-    background-image: url(../gold/creddits-snoo.png);
+    background-image: url(./gold/creddits-snoo.png);
   }
 }
 
 .gold-page.gilding {
   .gold-banner {
-    background-image: url(../gold/reddit-gilding.png);
+    background-image: url(./gold/reddit-gilding.png);
   }
 
   dt {
@@ -10974,17 +10974,17 @@ body.with-listing-chooser {
 
       &.userpage-gild {
         height: 227px;
-        background: url('../gold/userpage-gild.png') no-repeat center center;
+        background: url('./gold/userpage-gild.png') no-repeat center center;
       }
 
       &.comment-gild {
         height: 160px;
-        background: url('../gold/comment-gild.png') no-repeat top left;
+        background: url('./gold/comment-gild.png') no-repeat top left;
       }
 
       &.using-creddits {
         height: 90px;
-        background: url('../gold/using-creddits.png') no-repeat top left;
+        background: url('./gold/using-creddits.png') no-repeat top left;
       }
     }
   }
@@ -11003,17 +11003,17 @@ body.with-listing-chooser {
   .gold-page.gilding .example figure {
 
     &.userpage-gild {
-        background: url('../gold/userpage-gild-x2.png') no-repeat center center;
+        background: url('./gold/userpage-gild-x2.png') no-repeat center center;
         background-size: 339px 227px;
       }
 
     &.comment-gild {
-        background: url('../gold/comment-gild-x2.png') no-repeat top left;
+        background: url('./gold/comment-gild-x2.png') no-repeat top left;
         background-size: 339px 160px;
       }
 
     &.using-creddits {
-        background: url('../gold/using-creddits-x2.png') no-repeat top left;
+        background: url('./gold/using-creddits-x2.png') no-repeat top left;
         background-size: 339px 90px;
       }
   }
@@ -11041,11 +11041,11 @@ body.with-listing-chooser {
       }
 
       #mail.havemail {
-        background-image: url(../gold/gold-only-mail-havemail.png); /* SPRITE */
+        background-image: url(./gold/gold-only-mail-havemail.png); /* SPRITE */
       }
 
       #modmail.havemail {
-        background-image: url(../gold/gold-only-modmail-havemail.png); /* SPRITE */
+        background-image: url(./gold/gold-only-modmail-havemail.png); /* SPRITE */
       }
     }
 
@@ -11072,11 +11072,11 @@ body.with-listing-chooser {
   }
 
   .arrow.upmod { 
-    background-image: url(../gold/gold-only-upvote-mod.png); /* SPRITE */
+    background-image: url(./gold/gold-only-upvote-mod.png); /* SPRITE */
   }
 
   .arrow.downmod { 
-    background-image: url(../gold/gold-only-downvote-mod.png); /* SPRITE */
+    background-image: url(./gold/gold-only-downvote-mod.png); /* SPRITE */
   }
 
   .link .score.dislikes {
@@ -11092,7 +11092,7 @@ body.with-listing-chooser {
 
 .quarantine {
   #header-img.default-header {
-    background-image: url(../quarantine-header.png); /* SPRITE */
+    background-image: url(./quarantine-header.png); /* SPRITE */
     width: 40px;
     height: 40px;
     margin-left: 3px;
@@ -11219,8 +11219,8 @@ body.with-listing-chooser {
 
     .action-icon-info {
         .hdpi-bg-image(
-            @1x: url(../action-icon-info-color.png),
-            @2x: url(../action-icon-info-color_2x.png)
+            @1x: url(./action-icon-info-color.png),
+            @2x: url(./action-icon-info-color_2x.png)
         );
     }
 
@@ -11458,31 +11458,31 @@ body:not(.loggedin) .report-button {
     height: 16px;
 
     &.sr-type-icon-banned {
-        .hdpi-bg-image(@1x: url(../sr-type-icon-banned.png), @2x: url(../sr-type-icon-banned_2x.png));
+        .hdpi-bg-image(@1x: url(./sr-type-icon-banned.png), @2x: url(./sr-type-icon-banned_2x.png));
     }
 
     &.sr-type-icon-moderator {
-        .hdpi-bg-image(@1x: url(../sr-type-icon-moderator.png), @2x: url(../sr-type-icon-moderator_2x.png));
+        .hdpi-bg-image(@1x: url(./sr-type-icon-moderator.png), @2x: url(./sr-type-icon-moderator_2x.png));
     }
 
     &.sr-type-icon-approved {
-        .hdpi-bg-image(@1x: url(../sr-type-icon-approved.png), @2x: url(../sr-type-icon-approved_2x.png));
+        .hdpi-bg-image(@1x: url(./sr-type-icon-approved.png), @2x: url(./sr-type-icon-approved_2x.png));
     }
 
     &.sr-type-icon-restricted {
-        .hdpi-bg-image(@1x: url(../sr-type-icon-restricted.png), @2x: url(../sr-type-icon-restricted_2x.png));
+        .hdpi-bg-image(@1x: url(./sr-type-icon-restricted.png), @2x: url(./sr-type-icon-restricted_2x.png));
     }
 
     &.sr-type-icon-private {
-        .hdpi-bg-image(@1x: url(../sr-type-icon-private.png), @2x: url(../sr-type-icon-private_2x.png));
+        .hdpi-bg-image(@1x: url(./sr-type-icon-private.png), @2x: url(./sr-type-icon-private_2x.png));
     }
 
     &.sr-type-icon-quarantined {
-        .hdpi-bg-image(@1x: url(../sr-type-icon-quarantined.png), @2x: url(../sr-type-icon-quarantined_2x.png));
+        .hdpi-bg-image(@1x: url(./sr-type-icon-quarantined.png), @2x: url(./sr-type-icon-quarantined_2x.png));
     }
 
     &.sr-type-icon-nsfw {
-        .hdpi-bg-image(@1x: url(../sr-type-icon-nsfw.png), @2x: url(../sr-type-icon-nsfw_2x.png));
+        .hdpi-bg-image(@1x: url(./sr-type-icon-nsfw.png), @2x: url(./sr-type-icon-nsfw_2x.png));
     }
 }
 

--- a/r2/r2/public/static/css/subreddit-rules.less
+++ b/r2/r2/public/static/css/subreddit-rules.less
@@ -133,8 +133,8 @@
     position: relative;
     
     &:before {
-        .hdpi-bg-image(@1x: url(../modtools-page-icon-rules.png),
-                       @2x: url(../modtools-page-icon-rules_2x.png));
+        .hdpi-bg-image(@1x: url(./modtools-page-icon-rules.png),
+                       @2x: url(./modtools-page-icon-rules_2x.png));
 
         content: '';
         display: block;

--- a/r2/r2/templates/less.html
+++ b/r2/r2/templates/less.html
@@ -39,7 +39,7 @@
 <%def name="less_js()">
   %if g.uncompressedJS:
     <script type="text/javascript">
-      less = {env: 'development'};
+      less = {env: 'development', rootpath: '${static('')}'};
     </script>
     ${unsafe(js.use('less'))}
   %endif


### PR DESCRIPTION
Relative urls to the parent directory on local installs (build/public) don't have a file to match, so Pylons takes over, and itself fails because the only thing it matches is a potential url (ex `droparrowgray.gif` being a domain name), and then redirects to a submit page to submit it.

Being relative to the same directory is what is needed on local installs, and what is supposed to be done on installs using a static domain. The only reason the real static domain still works is because all files are located in the root directory, and the parent directory of the root directory of a site is considered to be itself.

Two other changes were made to the spritesheet generator and on-the-fly less parser, because the images are located in the parent directory relative to the original `{name}.less/compact.css` file that it gets passed, so it needs to search one directory above now by itself.

For context, the changes to the static files were done via the following script

```
reddit@ubuntu:~/src/reddit/r2$ cd r2/public/static/css && python
>>> from glob import glob
>>> for fpath in (glob('./*.*ss') + glob('./components/*.*ss')):
...     with open(fpath, 'r+') as f:
...         data = f.read().replace('url(../', 'url(./').replace('url("../', 'url("./').replace("url('../", "url('./")
...         f.seek(0); f.truncate(); f.write(data)
```

Resolves #1722 