### PR TITLE
Add friends feeds to private rss feeds page

### DIFF
--- a/r2/r2/templates/preffeeds.html
+++ b/r2/r2/templates/preffeeds.html
@@ -127,5 +127,15 @@ ${unsafe(safemarkdown(_("All feeds are invalidated if you change your password, 
     </td>
   </tr>
   %endif
+  <tr>
+    <th>your friends</th>
+    <td class="prefright">
+      <%self:feedbuttons path="/r/friends"></%self:feedbuttons>
+      ${_("your friends' links")}
+      <br/>
+      <%self:feedbuttons path="/r/friends/comments"></%self:feedbuttons>
+      ${_("your friends' comments")}
+    </td>
+  </tr>
 </table>
 </div>


### PR DESCRIPTION
Adds links for `friends` and `friends/comments` to the private rss feed listing. I added the links to a new section below moderator feeds, but I'm open to putting them elsewhere. If there are related files I should change, please let me know.

I tested that the generated feed URL works by hijacking one of the existing private feed urls and pointing it at `friends` and `friends/comments` instead. Both worked.