### PR TITLE
Typo: Travis doesn't have a "postgres" service, only "postgresql"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ virtualenv:
     system_site_packages: true
 
 services:
-    - postgres
+    - postgresql
     - memcached
     - rabbitmq
 


### PR DESCRIPTION
Travis is skipping this service as a result.

This doesn't resolve the build errors, which is another issue in and of itself, but I'm semi surprised that the build had worked without this in the first place, unless the corresponding tests were never added.