### PR TITLE
Search: Fix restrict_sr for domains listings and AllMinus

### DIFF
--- a/r2/r2/lib/providers/search/cloudsearch.py
+++ b/r2/r2/lib/providers/search/cloudsearch.py
@@ -51,6 +51,7 @@ from r2.lib.providers.search.common import (
 import r2.lib.utils as r2utils
 from r2.models import (
     Account,
+    AllMinus,
     DomainSR,
     FakeSubreddit,
     FriendsSR,
@@ -751,7 +752,7 @@ class LinkSearchQuery(CloudSearchQuery):
     @staticmethod
     def _restrict_sr(sr):
         '''Return a cloudsearch appropriate query string that restricts
-        results to only contain results from self.sr
+        results to only contain results from sr
         
         '''
         if isinstance(sr, MultiReddit):
@@ -760,7 +761,7 @@ class LinkSearchQuery(CloudSearchQuery):
             srs = ["sr_id:%s" % sr_id for sr_id in sr.sr_ids]
             return "(or %s)" % ' '.join(srs)
         elif isinstance(sr, DomainSR):
-            return "site:'%s'" % sr.domain
+            return "site:'\"%s\"'" % sr.domain
         elif isinstance(sr, FriendsSR):
             if not c.user_is_loggedin or not c.user.friends:
                 raise InvalidQuery
@@ -771,6 +772,11 @@ class LinkSearchQuery(CloudSearchQuery):
                        Account._fullname_from_id36(r2utils.to36(id_))
                        for id_ in friend_ids]
             return "(or %s)" % ' '.join(friends)
+        elif isinstance(sr, AllMinus):
+            if not sr.exclude_sr_ids:
+                raise InvalidQuery
+            exclude_srs = ["sr_id:%s" % sr_id for sr_id in sr.exclude_sr_ids]
+            return "(not (or %s))" % ' '.join(exclude_srs)
         elif not isinstance(sr, FakeSubreddit):
             return "sr_id:%s" % sr._id
 

--- a/r2/r2/lib/providers/search/solr.py
+++ b/r2/r2/lib/providers/search/solr.py
@@ -52,12 +52,12 @@ import r2.lib.utils as r2utils
 from r2.models import (
         Account, 
         All, 
+        AllMinus,
         DefaultSR,
         DomainSR, 
         FakeSubreddit, 
         Friends, 
         Link, 
-        ModContribSR,
         MultiReddit, 
         NotFound,
         Subreddit, 
@@ -337,7 +337,7 @@ class LinkSearchQuery(SolrSearchQuery):
     @staticmethod
     def _get_sr_restriction(sr):
         '''Return a solr-appropriate query string that restricts
-        results to only contain results from self.sr
+        results to only contain results from sr
         
         '''
         bq = []
@@ -356,9 +356,9 @@ class LinkSearchQuery(SolrSearchQuery):
                        Account._fullname_from_id36(r2utils.to36(id_))
                        for id_ in friend_ids]
             bq.extend(friends)
-        elif isinstance(sr, ModContribSR):
-            for sr_id in sr.sr_ids:
-                bq.append("sr_id:%s" % sr_id)
+        elif isinstance(sr, AllMinus):
+            for sr_id in sr.exclude_sr_ids:
+                bq.append("-sr_id:%s" % sr_id)
         elif not isinstance(sr, FakeSubreddit):
             bq = ["sr_id:%s" % sr._id]
         return ' OR '.join(bq)

--- a/r2/r2/lib/providers/search/solr.py
+++ b/r2/r2/lib/providers/search/solr.py
@@ -39,40 +39,41 @@ from r2.lib.db.operators import desc
 from r2.lib.db.sorts import epoch_seconds
 from r2.lib.providers.search import SearchProvider
 from r2.lib.providers.search.common import (
-        InvalidQuery, 
-        LinkFields, 
+        InvalidQuery,
+        LinkFields,
         Results,
-        safe_get, 
+        safe_get,
         safe_xml_str,
         SearchError,
-        SearchHTTPError, 
-        SubredditFields, 
+        SearchHTTPError,
+        SubredditFields,
     )
 import r2.lib.utils as r2utils
 from r2.models import (
-        Account, 
-        All, 
+        Account,
+        All,
         AllMinus,
         DefaultSR,
-        DomainSR, 
-        FakeSubreddit, 
-        Friends, 
-        Link, 
-        MultiReddit, 
+        DomainSR,
+        FakeSubreddit,
+        Friends,
+        Link,
+        MultiReddit,
         NotFound,
-        Subreddit, 
+        Subreddit,
         Thing,
     )
 
 
-_CHUNK_SIZE = 4000000 # Approx. 4 MB, to stay under the 5MB limit
-DEFAULT_FACETS = {"reddit": {"count":20}}
+_CHUNK_SIZE = 4000000  # Approx. 4 MB, to stay under the 5MB limit
+DEFAULT_FACETS = {"reddit": {"count": 20}}
 
 WARNING_XPATH = ".//lst[@name='error']/str[@name='warning']"
 STATUS_XPATH = ".//lst/int[@name='status']"
 
 SORTS_DICT = {'text_relevance': 'score',
               'relevance': 'score'}
+
 
 def basic_query(query=None, bq=None, faceting=None, size=1000,
                 start=0, rank="", return_fields=None, record_stats=False,
@@ -100,7 +101,8 @@ def basic_query(query=None, bq=None, faceting=None, size=1000,
                 pass
             else:
                 if 'error' in response_json:
-                    message = response_json['error'].get('msg', 'Unknown error')
+                    message = response_json['error'].get('msg',
+                                                         'Unknown error')
                     raise InvalidQuery(resp.status, resp.reason, message,
                                        search_api, path, reasons)
             raise SearchHTTPError(resp.status, resp.reason,
@@ -156,7 +158,7 @@ class SolrSearchQuery(object):
         self._recent = recent
         self.recent = self.recents[recent]
         self.include_over18 = include_over18
-        
+
         # rank / rank expressions
         self._sort = sort
         if raw_sort:
@@ -173,7 +175,7 @@ class SolrSearchQuery(object):
 
         # facets
         self.faceting = faceting
-        
+
         self.results = None
 
     def run(self, after=None, reverse=False, num=1000, _update=False):
@@ -189,7 +191,7 @@ class SolrSearchQuery(object):
 
     def _run(self, start=0, num=1000, _update=False):
         '''Run the search against self.query'''
-        
+
         q = self.query.encode('utf-8')
         if g.sqlprinting:
             g.log.info("%s", self)
@@ -218,7 +220,7 @@ class SolrSearchQuery(object):
                     num=1000, _update=False):
         '''Query the solr HOST. _update parameter allows for supposed
         easy memoization at later date.
-        
+
         Example result set:
         {
             u'responseHeader':{
@@ -226,7 +228,6 @@ class SolrSearchQuery(object):
                 u'QTime':2,
                 u'params':{
                     u'sort':u'activity desc',
-                    u'defType':u'edismax',
                     u'q':u'coffee',
                     u'start':u'0',
                     u'wt':u'json',
@@ -247,15 +248,15 @@ class SolrSearchQuery(object):
                         u'num_comments':0,
                         u'downs':1,
                         u'title':u'013',
-                        u'site':u"[u'reddit.com',u'hamsandwich.reddit.com']", 
-                        u'author_s': u'grandpa', 
-                        u'over18': False, 
-                        u'timestamp': 1427180669, 
-                        u'sr_id': 2, 
-                        u'author_fullname': u't2_1', 
-                        u'is_self': False, 
-                        u'subreddit': u'coffee', 
-                        u'ups': 0, u'id': u't5_3'}, 
+                        u'site':u"[u'reddit.com',u'hamsandwich.reddit.com']",
+                        u'author_s': u'grandpa',
+                        u'over18': False,
+                        u'timestamp': 1427180669,
+                        u'sr_id': 2,
+                        u'author_fullname': u't2_1',
+                        u'is_self': False,
+                        u'subreddit': u'coffee',
+                        u'ups': 0, u'id': u't5_3'},
                     {
                 ]
             }
@@ -265,8 +266,8 @@ class SolrSearchQuery(object):
             return Results([], 0, {})
         try:
             response = basic_query(query=query, bq=bq, size=num, start=start,
-                               rank=sort, search_api=cls.search_api,
-                               faceting=faceting, record_stats=True)
+                                   rank=sort, search_api=cls.search_api,
+                                   faceting=faceting, record_stats=True)
         except (SearchHTTPError, SearchError) as e:
             g.log.error("Search Error: %r", e)
             raise
@@ -281,8 +282,7 @@ class SolrSearchQuery(object):
                 while facet_fields[field]:
                     value = facet_fields[field].pop(0)
                     count = facet_fields[field].pop(0)
-                    facets[field].append(dict(value=value, count=count)) 
-            
+                    facets[field].append(dict(value=value, count=count))
 
         results = Results(docs, hits, facets)
         return results
@@ -323,7 +323,7 @@ class LinkSearchQuery(SolrSearchQuery):
     def create_boolean_query(cls, queries):
         '''Return an AND clause combining all queries'''
         if len(queries) > 1:
-            bq = ' AND  '.join(['(%s)' %q for q in queries]) 
+            bq = ' AND  '.join(['(%s)' % q for q in queries])
         else:
             bq = queries[0]
         return bq
@@ -338,7 +338,7 @@ class LinkSearchQuery(SolrSearchQuery):
     def _get_sr_restriction(sr):
         '''Return a solr-appropriate query string that restricts
         results to only contain results from sr
-        
+
         '''
         bq = []
         if (not sr) or sr == All or isinstance(sr, DefaultSR):
@@ -379,10 +379,9 @@ def _encode_query(query, faceting, size, start, rank, return_fields):
     params = {}
     params["q"] = query
     params["wt"] = "json"
-    #params["defType"] = "edismax"
     params["size"] = size
     params["start"] = start
-    if rank: 
+    if rank:
         params['sort'] = rank.strip().lower()
         if not params['sort'].split()[-1] in ['asc', 'desc']:
             params['sort'] = '%s desc' % params['sort']
@@ -399,7 +398,7 @@ def _encode_query(query, faceting, size, start, rank, return_fields):
                 facet_sort.append(options["sort"])
         params["facet.limit"] = ",".join([str(l) for l in facet_limit])
         params["facet.sort"] = ",".join(facet_sort)
-        params["facet.sort"] = params["facet.sort"] or 'score desc' 
+        params["facet.sort"] = params["facet.sort"] or 'score desc'
     if return_fields:
         params["qf"] = ",".join(return_fields)
     encoded_query = urllib.urlencode(params)
@@ -407,16 +406,16 @@ def _encode_query(query, faceting, size, start, rank, return_fields):
         path = '/solr/%s/select?%s' % \
             (getattr(g, 'solr_core', 'collection1'), encoded_query)
     else:
-        path = '/solr/select?%s' %  encoded_query
-    return path    
+        path = '/solr/select?%s' % encoded_query
+    return path
 
 
 class SolrSearchUploader(object):
-    
+
     def __init__(self, solr_host=None, solr_port=None, fullnames=None):
         self.solr_host = solr_host or g.solr_doc_host
         self.solr_port = solr_port or g.solr_port
-        self.fullnames = fullnames    
+        self.fullnames = fullnames
 
     @classmethod
     def desired_fullnames(cls, items):
@@ -445,7 +444,7 @@ class SolrSearchUploader(object):
     def delete_xml(self, thing):
         '''Return the solr XML representation of
         "delete this from the index"
-        
+
         '''
         delete = etree.fromstring('<id>%s</id>' % thing._id)
         return delete
@@ -453,31 +452,29 @@ class SolrSearchUploader(object):
     def delete_ids(self, ids):
         '''Delete documents from the index.
         'ids' should be a list of fullnames
-        
-        '''
-        deletes = [etree.fromstring('<id>%s</id>' % id_) \
-                for id_ in ids]
 
+        '''
+        deletes = [etree.fromstring('<id>%s</id>' % id_) for id_ in ids]
 
         batch = etree.Element("delete")
         batch.extend(deletes)
         return self.send_documents(batch)
 
-    def batch_lookups(self):                                                                                            
-        try:                                                                                                            
-            self.things = Thing._by_fullname(self.fullnames, data=True,                                                 
-                                             return_dict=False)                                                         
-        except NotFound:                                                                                                
-            if self.use_safe_get:                                                                                       
-                self.things = safe_get(Thing._by_fullname, self.fullnames,                                              
-                                       data=True, return_dict=False)                                                    
-            else:                                                                                                       
-                raise 
+    def batch_lookups(self):
+        try:
+            self.things = Thing._by_fullname(self.fullnames, data=True,
+                                             return_dict=False)
+        except NotFound:
+            if self.use_safe_get:
+                self.things = safe_get(Thing._by_fullname, self.fullnames,
+                                       data=True, return_dict=False)
+            else:
+                raise
 
     def xml_from_things(self):
         '''Generate a <batch> XML tree to send to solr for
         adding/updating/deleting the given things
-        
+
         '''
         add = etree.Element("add")
         delete = etree.Element("delete")
@@ -516,11 +513,10 @@ class SolrSearchUploader(object):
             elems.append(commit)
         return elems
 
-
     def inject(self, quiet=False):
         '''Send things to solr. Return value is time elapsed, in seconds,
         of the communication with the solr endpoint
-        
+
         '''
 
         xml_things = self.xml_from_things()
@@ -537,7 +533,7 @@ class SolrSearchUploader(object):
                 response = etree.fromstring(record)
                 status = response.find(STATUS_XPATH).text
                 if status == '0':
-                    # success! 
+                    # success!
                     adds += len(batch.findall('doc'))
                     deletes += len(batch.findall('delete'))
                     for w in response.find(WARNING_XPATH) or []:
@@ -546,7 +542,7 @@ class SolrSearchUploader(object):
             g.stats.simple_event("solrsearch.uploads.adds", delta=adds)
             g.stats.simple_event("solrsearch.uploads.deletes", delta=deletes)
             g.stats.simple_event("solrsearch.uploads.warnings",
-                    delta=len(warnings))
+                                 delta=len(warnings))
 
             if not quiet:
                 print "%s Changes: +%i -%i" % (self.__class__.__name__,
@@ -555,16 +551,16 @@ class SolrSearchUploader(object):
                     print "%s Warnings: %s" % (self.__class__.__name__,
                                                "; ".join(warnings))
 
-        return cs_time    
+        return cs_time
 
     def send_documents(self, docs):
         '''Open a connection to the Solr endpoint, and send the documents
         for indexing. Multiple requests are sent if a large number of documents
         are being sent (see chunk_xml())
-        
+
         Raises SearchHTTPError if the endpoint indicates a failure
         '''
-        core = getattr(g, 'solr_core', 'collection1') 
+        core = getattr(g, 'solr_core', 'collection1')
         responses = []
         connection = httplib.HTTPConnection(self.solr_host, self.solr_port)
         chunker = chunk_xml(docs)
@@ -576,7 +572,7 @@ class SolrSearchUploader(object):
                 if getattr(g, 'solr_version', '1').startswith('4'):
                     connection.request('POST', "/solr/%s/update/" % core,
                                        data, headers)
-                else:     
+                else:
                     connection.request('POST', "/solr/update/",
                                        data, headers)
                 response = connection.getresponse()
@@ -584,8 +580,8 @@ class SolrSearchUploader(object):
                     responses.append(response.read())
                 else:
                     raise SearchHTTPError(response.status,
-                                               response.reason,
-                                               response.read())
+                                          response.reason,
+                                          response.read())
         finally:
             connection.close()
         return responses
@@ -593,7 +589,7 @@ class SolrSearchUploader(object):
 
 def chunk_xml(xml, depth=0):
     '''Chunk POST data into pieces that are smaller than the 20 MB limit.
-    
+
     Ideally, this never happens (if chunking is necessary, would be better
     to avoid xml'ifying before testing content_length)'''
     data = etree.tostring(xml)
@@ -605,7 +601,7 @@ def chunk_xml(xml, depth=0):
         depth += 1
         print "WARNING: Chunking (depth=%s)" % depth
         half = len(xml) / 2
-        left_half = xml # for ease of reading
+        left_half = xml  # For ease of reading
         right_half = etree.Element(root)
         # etree magic simultaneously removes the elements from one tree
         # when they are appended to a different tree
@@ -620,7 +616,7 @@ def chunk_xml(xml, depth=0):
 def _run_changed(msgs, chan):
     '''Consume the cloudsearch_changes queue, and print reporting information
     on how long it took and how many remain
-    
+
     '''
     start = datetime.now(g.tz)
 
@@ -631,7 +627,7 @@ def _run_changed(msgs, chan):
 
     link_uploader = SolrLinkUploader(g.solr_doc_host, fullnames=link_fns)
     subreddit_uploader = SolrSubredditUploader(g.solr_subreddit_doc_host,
-                                           fullnames=sr_fns)
+                                               fullnames=sr_fns)
 
     link_time = link_uploader.inject()
     subreddit_time = subreddit_uploader.inject()
@@ -687,7 +683,7 @@ class SolrLinkUploader(SolrSearchUploader):
 
     def should_index(self, thing):
         return (thing.promoted is None and getattr(thing, "sr_id", None) != -1)
-    
+
 
 class SolrSubredditUploader(SolrSearchUploader):
     types = (Subreddit,)
@@ -698,14 +694,14 @@ class SolrSubredditUploader(SolrSearchUploader):
     def should_index(self, thing):
         return thing._id != Subreddit.get_promote_srid()
 
- 
+
 def _progress_key(item):
     return "%s/%s" % (item._id, item._date)
 
 
 def _rebuild_link_index(start_at=None, sleeptime=1, cls=Link,
-                       uploader=SolrLinkUploader, estimate=50000000, 
-                       chunk_size=1000):
+                        uploader=SolrLinkUploader, estimate=50000000,
+                        chunk_size=1000):
     uploader = uploader()
 
     q = cls._query(cls.c._deleted == (True, False), sort=desc('_date'))
@@ -720,7 +716,7 @@ def _rebuild_link_index(start_at=None, sleeptime=1, cls=Link,
                          key=_progress_key)
     for chunk in r2utils.in_chunks(q, size=chunk_size):
         uploader.things = chunk
-        uploader.fullnames = [c._fullname for c in chunk] 
+        uploader.fullnames = [c._fullname for c in chunk]
         for x in range(5):
             try:
                 uploader.inject()
@@ -767,14 +763,15 @@ def _translate_raw_sort(sort):
     if sort.startswith('-'):
         sort = sort[1:]
         sort_dir = ' desc'
-    sort = SORTS_DICT.get(sort, sort) 
+    sort = SORTS_DICT.get(sort, sort)
     return '%s%s' % (sort, sort_dir)
+
 
 class SolrSearchProvider(SearchProvider):
     '''Provider implementation: wrap it all up as a SearchProvider
-    
+
     example config:
-    # version of solr service--versions 1.x and 4.x have been tested. 
+    # version of solr service--versions 1.x and 4.x have been tested.
     # only the major version number matters here
     solr_version = 1
     # solr search service hostname or IP
@@ -789,17 +786,17 @@ class SolrSearchProvider(SearchProvider):
     solr_port = 8080
     # solr4 core name (not used with Solr 1.x)
     solr_core = collection1
-    # default batch size 
+    # default batch size
     # limit is hard-coded to 1000
     # set to 1 for testing
     solr_min_batch = 500
     # optionally, you may select your solr query parser here
     # see documentation for your version of Solr
-    solr_query_parser = 
+    solr_query_parser =
     '''
 
     SOLR_VERSION = 1
-  
+
     config = {
         ConfigValue.int: [
             "solr_port",
@@ -813,7 +810,7 @@ class SolrSearchProvider(SearchProvider):
             "solr_core",
             "solr_version",
         ],
-    }    
+    }
 
     InvalidQuery = (InvalidQuery,)
     SearchException = (SearchHTTPError, SearchError)
@@ -821,19 +818,21 @@ class SolrSearchProvider(SearchProvider):
     SearchQuery = LinkSearchQuery
 
     SubredditSearchQuery = SolrSubredditSearchQuery
-    
-    def run_changed(self, drain=False, min_size=int(getattr(g, 'solr_min_batch', 500)), limit=1000, sleep_time=10, 
-            use_safe_get=False, verbose=False):
+
+    def run_changed(self, drain=False,
+                    min_size=int(getattr(g, 'solr_min_batch', 500)),
+                    limit=1000, sleep_time=10, use_safe_get=False,
+                    verbose=False):
         '''Run by `cron` (through `paster run`) on a schedule to send Things to Solr
         '''
         if use_safe_get:
             SolrSearchUploader.use_safe_get = True
-        amqp.handle_items('cloudsearch_changes', _run_changed, min_size=min_size,
-                          limit=limit, drain=drain, sleep_time=sleep_time,
-                          verbose=verbose)
+        amqp.handle_items('cloudsearch_changes', _run_changed,
+                          min_size=min_size, limit=limit, drain=drain,
+                          sleep_time=sleep_time, verbose=verbose)
 
     def rebuild_link_index(self, start_at=None, sleeptime=1, cls=Link,
-                           uploader=SolrLinkUploader, estimate=50000000, 
+                           uploader=SolrLinkUploader, estimate=50000000,
                            chunk_size=1000):
-         _rebuild_link_index(start_at, sleeptime, cls, uploader, estimate,  
+        _rebuild_link_index(start_at, sleeptime, cls, uploader, estimate,
                             chunk_size)


### PR DESCRIPTION
This PR fixes a few issues with the `restrict_sr` property.  Most of the important information is in the commit message:

> For domains listings, it was possible to have results from the wrong domain be included.  Switching to a phrase search fixes that.  See https://redd.it/5ew4ve for more info about, and caveats of, this method.

> For AllMinus, see https://redd.it/5eqiyy for the general context.  This does not need to be explicitly handled for ModMinus, as ModMinus excludes the filtered subreddits from its sr_ids property.  Additionally, ModMinus doesn't need special handling since it inherits the already-handled MultiReddit.

Note that I have _not_ tested this code on a reddit instance (since I don't have cloudsearch), but I did test the individual queries manually (and they work).  I also haven't tested the solr queries at all, but it looks correct per the solr docs.  That entire solr `_get_sr_restriction` seems a bit fishy, though (especially, for instance, `sr == All`), but since I can't test solr I'm not sure if that's actually correct or not.  I'm not sure if solr is actually used anywhere, so I haven't investigated further.

I also reformatted all of cloudsearch.py and solr.py, since they weren't following the style guide.

[Diff excluding whitespace-only changes](https://github.com/reddit/reddit/pull/1735/files?w=1) ([info](https://github.com/blog/967-github-secrets))