### PR TITLE
Ensure PyCrypto v2.6.1 is used.

### DIFF
--- a/r2/setup.py
+++ b/r2/setup.py
@@ -62,7 +62,7 @@ setup(
         "mako>=0.5",
         "boto >= 2.0",
         "pytz",
-        "pycrypto",
+        "pycrypto>=2.6.1",
         "Babel>=1.0",
         "cython>=0.14",
         "SQLAlchemy",


### PR DESCRIPTION
Stable versions of PyCrypto prior to 2.6.1 are vulnerable to [CVE-2013-1445](https://lists.dlitz.net/pipermail/pycrypto/2013q4/000702.html).