### PR TITLE
Implement Content-Security-Policy (CSP)

### DIFF
--- a/r2/r2/controllers/reddit_base.py
+++ b/r2/r2/controllers/reddit_base.py
@@ -970,6 +970,22 @@ class MinimalController(BaseController):
         response.headers['X-Content-Type-Options'] = 'nosniff'
         response.headers['X-XSS-Protection'] = '1; mode=block'
 
+        # add CSP
+        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+        response.headers['content-security-policy'] = (
+            "default-src 'self';"
+            "script-src 'self' 'unsafe-inline' www.redditstatic.com;"
+            "style-src 'self' www.redditstatic.com;"
+            'img-src *;'
+            "font-src 'self' fonts.gstatic.com;"
+            "connect-src 'self' events.redditmedia.com googleads.g.doubleclick.net www.youtube.com *.googlevideo.com content.googleapis.com;"
+            'media-src *;'
+            'child-src www.redditmedia.com;'
+            'upgrade-insecure-requests;'
+            'block-all-mixed-content;'
+            'reflected-xss block;'
+        )
+
         if (feature.is_enabled("force_https")
                 and feature.is_enabled("upgrade_cookies")):
             upgrade_cookie_security()


### PR DESCRIPTION
Content Security Policy (CSP) is a security mechanism that allows websites to control how browsers process their pages. In essence, sites can restrict what types of resources are loaded and from where. CSP policies
can be used to defend against cross-site scripting, prevent mixed content issues, as well as report violations for investigation.

I am fairly sure that I have not supplied enough policies, therefore if you encounter warnings of any sort please report back and I will add them to the list.

For more on CSP please refer to the following page: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP