### PR TITLE
Fix severe jank on loading additional comments

### DIFF
--- a/r2/r2/public/static/js/jquery.reddit.js
+++ b/r2/r2/public/static/js/jquery.reddit.js
@@ -566,7 +566,7 @@ $.insert_things = function(things, append) {
             else
                 s = s.prepend($.unsafe(data.content)).children(".thing:first");
 
-            thing_init_func(s.hide().show());
+            thing_init_func(s);
             $(document).trigger('new_thing', s)
             return s;
         })


### PR DESCRIPTION
`.hide().show()` serves no apparent purpose, but causes a reflow since `hide` forces a style recalculation.

The reason why this is so severe, is that `add comment to DOM` then `check whether hidden` is repeated for each comment. Every time the DOM is changed, `jQuery.hide` forces the browser to do style recalculations on the parent `.siteTable` in order to check hidden status. This is especially expensive at the bottom "load more comments" since that recalculation will involve every comment thread.

Before:
![image](https://cloud.githubusercontent.com/assets/1748521/22130019/e11fadf4-dea9-11e6-81a5-862950d36622.png)

After:
![image](https://cloud.githubusercontent.com/assets/1748521/22130012/d330e0be-dea9-11e6-8273-9dd835cd0dfd.png)
