### PR TITLE
Fix contest mode.

### DIFF
--- a/r2/r2/lib/comment_tree.py
+++ b/r2/r2/lib/comment_tree.py
@@ -136,6 +136,7 @@ def get_comment_scores(link, sort, comment_ids, timer):
 
     from r2.lib.db import queries
     from r2.models import CommentScoresByLink
+    from random import randrange
 
     if not comment_ids:
         # no comments means no scores
@@ -145,6 +146,8 @@ def get_comment_scores(link, sort, comment_ids, timer):
         # comment ids are monotonically increasing, so we can use them as a
         # substitute for creation date
         scores_by_id = {comment_id: comment_id for comment_id in comment_ids}
+    elif sort == "_random":
+        scores_by_id = {comment_id: randrange(1, 10**10) for comment_id in comment_ids}
     else:
         scores_by_id36 = CommentScoresByLink.get_scores(link, sort)
 

--- a/r2/r2/models/builder.py
+++ b/r2/r2/models/builder.py
@@ -943,7 +943,7 @@ SORT_OPERATOR_BY_NAME = {
     "qa": operators.desc('_qa'),
     "hot": operators.desc('_hot'),
     "top": operators.desc('_score'),
-    "random": operators.shuffled('_confidence'),
+    "random": operators.shuffled('_random'),
 }
 
 
@@ -1481,14 +1481,6 @@ class CommentBuilder(Builder):
                 final.append(comment)
 
         self.timer.intermediate("build_comments")
-
-        if isinstance(self.sort, operators.shuffled):
-            # If we have a sticky comment, do not shuffle the first element
-            # of the list.
-            if len(final) > 0 and final[0]._id == self.link.sticky_comment_id:
-                shuffle_slice(final, 1)
-            else:
-                shuffle(final)
 
         if not self.load_more:
             timer.stop()


### PR DESCRIPTION
This assigns all comments a random score in contest mode, before they get split into `comment_tuples` and `missing_root_comments`. The current method doesn't include the `missing_root_comments` in the shuffle.

See #1758.