### PR TITLE
Improve Atom feeds

### DIFF
--- a/r2/r2/templates/link.xml
+++ b/r2/r2/templates/link.xml
@@ -98,6 +98,7 @@
 
     <id>${thing._fullname}</id>
     <link href="${permalink}" />
+    <link href="${permalink}" rel="replies" type="text/html" /> 
     <link href="${permalink}.rss" rel="replies" type="application/atom+xml" />
     %if thing.different_sr:
         <link href="${add_sr(thing.subreddit.path,

--- a/r2/r2/templates/link.xml
+++ b/r2/r2/templates/link.xml
@@ -115,7 +115,10 @@
             rel="related"
             type="application/atom+xml"
             title="/r/${thing.subreddit.name}" />
-    %endif  
+    %endif
+    %if not getattr(thing, 'selftext', None):
+        <link href="${thing.url}" rel="related" />
+    %endif
     <updated>${html_datetime(thing._date)}</updated>
     <title>${title}</title>
 </entry>

--- a/r2/r2/templates/link.xml
+++ b/r2/r2/templates/link.xml
@@ -98,6 +98,7 @@
 
     <id>${thing._fullname}</id>
     <link href="${permalink}" />
+    <link href="${permalink}.rss" rel="replies" type="application/atom+xml" />
     <updated>${html_datetime(thing._date)}</updated>
     <title>${title}</title>
 </entry>

--- a/r2/r2/templates/link.xml
+++ b/r2/r2/templates/link.xml
@@ -99,6 +99,22 @@
     <id>${thing._fullname}</id>
     <link href="${permalink}" />
     <link href="${permalink}.rss" rel="replies" type="application/atom+xml" />
+    %if thing.different_sr:
+        <link href="${add_sr(thing.subreddit.path,
+                          sr_path=False,
+                          retain_extension=False,
+                          force_hostname=True)}"
+            rel="related"
+            type="text/html"
+            title="/r/${thing.subreddit.name}" />
+        <link href="${add_sr(thing.subreddit.path,
+                          sr_path=False,
+                          retain_extension=False,
+                          force_hostname=True)}.rss"
+            rel="related"
+            type="application/atom+xml"
+            title="/r/${thing.subreddit.name}" />
+    %endif  
     <updated>${html_datetime(thing._date)}</updated>
     <title>${title}</title>
 </entry>


### PR DESCRIPTION
Add extra metadata to the Atom entries, link to the comments (Atom + HTML) and related links when not a self post or in a subreddit like /r/all.

Hopefully you could drop https://github.com/reddit/reddit/blob/6484a52fad73ea747ab21edf4182b67929e15b6f/r2/r2/templates/link.xml#L68 line 68-92 when client support is a bit better.

Note I've not tested this