### PR TITLE
Add the ability to get list of saved subreddits through API.

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -3335,6 +3335,23 @@ class ApiController(RedditController):
         return {'categories': categories}
 
     @require_oauth2_scope("save")
+    @json_validate(VUser())
+    @api_doc(api_section.links_and_comments)
+    def GET_saved_subreddits(self, responder):
+        """Get a list of subreddits to which the currently saved posts belong to.
+
+        See also: [/api/save](#POST_api_save).
+
+        """
+        if not c.user.gold:
+            abort(403)
+        subreddits = LinkSavesBySubreddit.get_saved_subreddits(c.user)
+        subreddits += CommentSavesBySubreddit.get_saved_subreddits(c.user)
+        subreddits = sorted(set(subreddits), key=lambda name: name.lower())
+        subreddits = [dict(subreddit=subreddit) for subreddit in subreddits]
+        return {'subreddits': subreddits}
+
+    @require_oauth2_scope("save")
     @noresponse(
         VUser(),
         VModhash(),


### PR DESCRIPTION
The reddit API currently allows for the categories that saved posts belong to be fetched through the `GET /api/saved_categories` call, but does not allow for saved subreddits to be fetched. 

The saved categories and saved subreddits are provided through a similar interface (the classes `LinkSavesByCategory` and `LinkSavesBySubreddit` respectively), so it would make sense to include an API endpoint for saved subreddits.

This pull request is motivated by the need for this endpoint for an application that I am building, and the method I am currently using to get the list of saved subreddits (scraping the HTML of the rendered page) is not ideal.

The code is essentially mimicking the `GET_saved_categories()` method but with the appropriate model. I can see a benefit in extracting this logic to a common component and specifying which type of saved listing to fetch, but that could be reviewed in this PR.