### PR TITLE
Add new user agent detector for Android

### DIFF
--- a/r2/r2/lib/utils/reddit_agent_parser.py
+++ b/r2/r2/lib/utils/reddit_agent_parser.py
@@ -103,7 +103,7 @@ class RedditIsFunDetector(RedditBrowser):
 
 
 @register_detector
-class RedditAndroidDetectorOld(RedditBrowser):
+class OldRedditAndroidDetector(RedditBrowser):
     is_app = True
     look_for = 'RedditAndroid'
     name = 'Reddit: The Official App'

--- a/r2/r2/lib/utils/reddit_agent_parser.py
+++ b/r2/r2/lib/utils/reddit_agent_parser.py
@@ -103,11 +103,21 @@ class RedditIsFunDetector(RedditBrowser):
 
 
 @register_detector
-class RedditAndroidDetector(RedditBrowser):
+class RedditAndroidDetectorOld(RedditBrowser):
     is_app = True
     look_for = 'RedditAndroid'
     name = 'Reddit: The Official App'
     agent_string = '{look_for} (?P<version>{version_string})$'
+
+
+@register_detector
+class RedditAndroidDetector(RedditBrowser):
+    is_app = True
+    look_for = 'Reddit'
+    name = 'Reddit: The Official App'
+    agent_string = (
+        '{look_for}\/Version (?P<version>{version_string})\/Build '
+        '(?P<b_number>\d+)\/(?P<platform>.*?) (?P<pversion>{version_string})')
 
 
 @register_detector


### PR DESCRIPTION
Adds a new detector for the current user agent string that the Android app is using. Renames the old one so we can keep capturing old user agents.

Format (from Android strings.xml): `Reddit/Version %1$s/Build %2$s/Android %3$s`
Example: Reddit/Version 2.1.11/Build 20111/Android 6.0.1