### PR TITLE
Fix #1768

### DIFF
--- a/r2/r2/lib/utils/utils.py
+++ b/r2/r2/lib/utils/utils.py
@@ -1545,6 +1545,8 @@ class SimpleSillyStub(object):
     def stub(self, *args, **kwargs):
         pass
 
+    __exit__ = __enter__ = stub
+
 def strordict_fullname(item, key='fullname'):
     """Sometimes we migrate AMQP queues from simple strings to pickled
     dictionaries. During the migratory period there may be items in


### PR DESCRIPTION
Allow SimpleSillyStub to be used as context manager, fixing  #1768 (which was introduced in 61bda1b).