### PR TITLE
Add missing PrivateMessages required oauth2 scope to msg un/collapse

### DIFF
--- a/r2/r2/controllers/api.py
+++ b/r2/r2/controllers/api.py
@@ -3397,6 +3397,7 @@ class ApiController(RedditController):
                     t.to_collapse = collapse
             t._commit()
 
+    @require_oauth2_scope("privatemessages")
     @noresponse(VUser(),
                 VModhash(),
                 things = VByName('id', multiple = True))
@@ -3409,6 +3410,7 @@ class ApiController(RedditController):
         """
         self.collapse_handler(things, True)
 
+    @require_oauth2_scope("privatemessages")
     @noresponse(VUser(),
                 VModhash(),
                 things = VByName('id', multiple = True))


### PR DESCRIPTION
Add the missing PrivateMessages scope to the oauth2 requirements so that you can collapse and uncollapse messages.