### PR TITLE
Update Baseplate.configure_tracing call

### DIFF
--- a/r2/r2/lib/app_globals.py
+++ b/r2/r2/lib/app_globals.py
@@ -479,7 +479,7 @@ class Globals(object):
         self.baseplate.configure_logging()
         self.baseplate.register(R2BaseplateObserver())
         self.baseplate.configure_tracing(
-            service_name="r2",
+            r2,
             tracing_endpoint=self.config.get("tracing_endpoint"),
             sample_rate=self.config.get("tracing_sample_rate"),
         )


### PR DESCRIPTION
Baseplate changed the parameter name service_name to tracing_client.