### PR TITLE
Fix: baseplate.configure_tracing fixed to prevent an error with invalid arguments

### DIFF
--- a/r2/r2/lib/app_globals.py
+++ b/r2/r2/lib/app_globals.py
@@ -479,7 +479,7 @@ class Globals(object):
         self.baseplate.configure_logging()
         self.baseplate.register(R2BaseplateObserver())
         self.baseplate.configure_tracing(
-            service_name="r2",
+            "r2",
             tracing_endpoint=self.config.get("tracing_endpoint"),
             sample_rate=self.config.get("tracing_sample_rate"),
         )


### PR DESCRIPTION
## Problem
Changes in Baseplate repo: https://github.com/reddit/baseplate/commit/5ee9abbca69170bfda83a58dc613a97d9186f21f
Causes that error with invalid arguments
```
  File "/usr/bin/paster", line 4, in <module>
    command.run()
  File "/usr/lib/python2.7/dist-packages/paste/script/command.py", line 104, in run
    invoke(command, command_name, options, args[1:])
  File "/usr/lib/python2.7/dist-packages/paste/script/command.py", line 143, in invoke
    exit_code = runner.run(args)
  File "/usr/lib/python2.7/dist-packages/paste/script/command.py", line 238, in run
    result = self.command()
  File "/usr/lib/python2.7/dist-packages/paste/script/serve.py", line 284, in command
    relative_to=base, global_conf=vars)
  File "/usr/lib/python2.7/dist-packages/paste/script/serve.py", line 321, in loadapp
    **kw)
  File "/usr/lib/python2.7/dist-packages/paste/deploy/loadwsgi.py", line 247, in loadapp
    return loadobj(APP, uri, name=name, **kw)
  File "/usr/lib/python2.7/dist-packages/paste/deploy/loadwsgi.py", line 272, in loadobj
    return context.create()
  File "/usr/lib/python2.7/dist-packages/paste/deploy/loadwsgi.py", line 710, in create
    return self.object_type.invoke(self)
  File "/usr/lib/python2.7/dist-packages/paste/deploy/loadwsgi.py", line 146, in invoke
    return fix_call(context.object, context.global_conf, **context.local_conf)
  File "/usr/lib/python2.7/dist-packages/paste/deploy/util.py", line 58, in fix_call
    reraise(*exc_info)
  File "/usr/lib/python2.7/dist-packages/paste/deploy/compat.py", line 23, in reraise
    exec('raise t, e, tb', dict(t=t, e=e, tb=tb))
  File "/usr/lib/python2.7/dist-packages/paste/deploy/util.py", line 55, in fix_call
    val = callable(*args, **kw)
  File "/home/vagrant/src/reddit/r2/r2/__init__.py", line 41, in make_app
    return real_make_app(*args, **kwargs)
  File "/home/vagrant/src/reddit/r2/r2/config/middleware.py", line 506, in make_app
    config = load_environment(global_conf, app_conf)
  File "/home/vagrant/src/reddit/r2/r2/config/environment.py", line 69, in load_environment
    g = Globals(config, global_conf, app_conf, paths)
  File "/home/vagrant/src/reddit/r2/r2/lib/app_globals.py", line 484, in __init__
    sample_rate=self.config.get("tracing_sample_rate"),
TypeError: configure_tracing() takes at least 2 arguments (1 given); got ({'takedo...'1'}, cache_dir=...), wanted (*args, **kwargs)
```

## Solution:
There's no service_name argument in configure_tracing method. As it said in the code comment of the commit above:

```
# the first parameter was service_name before, so if it's not a client
# object we'll act like this is the old-style invocation and use the
# first parameter as service_name instead, passing on the old arguments
```

I've removed service_name argument, but I left "r2" there, it will be used as tracing_client's name further.