### PR TITLE
Punctuation and casing for wiki config descriptions

### DIFF
--- a/r2/r2/controllers/wiki.py
+++ b/r2/r2/controllers/wiki.py
@@ -92,11 +92,11 @@ from r2.lib.automoderator import Ruleset
 import json
 
 page_descriptions = {
-    "config/stylesheet": _("This page is the subreddit stylesheet, changes here apply to the subreddit css"),
-    "config/submit_text": _("The contents of this page appear on the submit page"),
-    "config/sidebar": _("The contents of this page appear on the subreddit sidebar"),
-    "config/description": _("The contents of this page appear in the public subreddit description and when the user does not have access to the subreddit"),
-    "config/automoderator": _("This page is used to configure AutoModerator for the subreddit, please see [the full documentation](/wiki/automoderator/full-documentation) for information"),
+    "config/stylesheet": _("This page is the subreddit stylesheet. Changes here apply to the subreddit CSS."),
+    "config/submit_text": _("The contents of this page appear on the submit page."),
+    "config/sidebar": _("The contents of this page appear on the subreddit sidebar."),
+    "config/description": _("The contents of this page appear in the public subreddit description and when the user does not have access to the subreddit."),
+    "config/automoderator": _("This page is used to configure AutoModerator for the subreddit. Please see [the full documentation](/wiki/automoderator/full-documentation) for information."),
 }
 
 ATTRIBUTE_BY_PAGE = {"config/sidebar": "description",


### PR DESCRIPTION
The config wiki page descriptions are a mix-match of commas, run-ons, and lowercase letters. This PR turns them into sentences while maintaining the same meaning for i18n purposes.