### PR TITLE
Rework AdminAwardGive to use description default

### DIFF
--- a/r2/r2/lib/pages/pages.py
+++ b/r2/r2/lib/pages/pages.py
@@ -3720,13 +3720,9 @@ class AdminAwards(Templated):
 class AdminAwardGive(Templated):
     """The interface for giving an award"""
     def __init__(self, award, recipient='', desc='', url='', hours=''):
-        now = datetime.datetime.now(g.display_tz)
-        if desc:
-            self.description = desc
-        elif award.awardtype == 'regular':
-            self.description = "??? -- " + now.strftime("%Y-%m-%d")
-        else:
-            self.description = ""
+        if award.awardtype == 'regular':
+            desc = "??? -- " + datetime.datetime.now(g.display_tz).strftime("%Y-%m-%d")
+        self.description = desc
         self.url = url
         self.recipient = recipient
         self.hours = hours


### PR DESCRIPTION
* No double initializing of the empty descriptor anymore.
* Time only retrieved if actually needed
* Better readability