### PR TITLE
add jsonp support to oembed endpoint

### DIFF
--- a/r2/r2/config/routing.py
+++ b/r2/r2/config/routing.py
@@ -71,7 +71,7 @@ def make_map(config):
 
     # redirect old urls to the new
     ABOUT_BASE = "https://about.reddit.com/"
-    mc('/about', controller='redirect', action='redirect', dest=ABOUT_BASE, 
+    mc('/about', controller='redirect', action='redirect', dest=ABOUT_BASE,
        conditions={'function':not_in_sr})
     mc('/about/values', controller='redirect', action='redirect', dest=ABOUT_BASE)
     mc('/about/team', controller='redirect', action='redirect',
@@ -171,7 +171,7 @@ def make_map(config):
           requirements=dict(controller="hot|new|rising|randomrising|ads"))
 
     mc('/user/:username/:where/:show', controller='user', action='listing')
-    
+
     mc('/explore', controller='front', action='explore')
     mc('/api/recommend/feedback', controller='api', action='rec_feedback')
 
@@ -307,7 +307,7 @@ def make_map(config):
     mc('/gold/thanks', controller='front', action='goldthanks')
     mc('/gold/subscription', controller='forms', action='subscription')
     mc('/gilding', controller='front', action='gilding')
-    mc('/creddits', controller='redirect', action='redirect', 
+    mc('/creddits', controller='redirect', action='redirect',
        dest='/gold?goldtype=creddits')
 
     mc('/password', controller='forms', action="password")
@@ -412,7 +412,7 @@ def make_map(config):
        conditions={"method": ["POST"]})
 
     mc('/api/:action', controller='api')
-    
+
     mc('/api/recommend/sr/:srnames', controller='api',
        action='subreddit_recommendations')
 

--- a/r2/r2/controllers/oembed.py
+++ b/r2/r2/controllers/oembed.py
@@ -170,9 +170,10 @@ class OEmbedController(MinimalController):
         url=VUrl('url'),
         parent=VBoolean("parent", default=False),
         live=VBoolean("live", default=False),
-        omitscript=VBoolean("omitscript", default=False)
+        omitscript=VBoolean("omitscript", default=False),
+        callback=VBoolean("callback", default=False)
     )
-    def GET_oembed(self, url, parent, live, omitscript):
+    def GET_oembed(self, url, parent, live, omitscript, callback):
         """Get the oEmbed response for a URL, if any exists.
 
         Spec: http://www.oembed.com/
@@ -180,7 +181,10 @@ class OEmbedController(MinimalController):
         Optional parameters (parent, live) are passed through as embed options
         to oEmbed renderers.
         """
-        response.content_type = "application/json"
+        if callback:
+            response.content_type = "application/javascript"
+        else:
+            response.content_type = "application/json"
 
         thing = url_to_thing(url)
         if not thing:


### PR DESCRIPTION
This is a naive solution to #1789, but I can't really figure out how JSONP support is working for other endpoints (`set_content_type` from `reddit_base.py` doesn't seem to be called anywhere, and nothing else is explicitly setting `application/javascript` content type for JSONP requests).

I'm not super great at python (though I've touched the oembed endpoint before 😅 ), so I'd appreciate pointers / more elegant solutions to this, thanks!