### PR TITLE
Find Python syntax errors or undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,17 @@ services:
     - memcached
     - rabbitmq
 
-install:
-    - sudo install/travis.sh travis .
-
-before_script:
+before_install:
     - pip install flake8
     # stop the build if there are Python syntax errors or undefined names
     - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
     # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
     - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+install:
+    - sudo install/travis.sh travis .
+
+before_script:
     - install/setup_rabbitmq.sh
     - install/setup_postgres.sh
     - install/setup_cassandra.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 sudo: required
-dist: trusty
 
 language: python
 
 python:
     - "2.7"
+    - "3.6"
+
+matrix:
+    allow_failures:
+        - python: "3.6"
 
 virtualenv:
     system_site_packages: true
@@ -18,6 +22,11 @@ install:
     - sudo install/travis.sh travis .
 
 before_script:
+    - pip install flake8
+    # stop the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - install/setup_rabbitmq.sh
     - install/setup_postgres.sh
     - install/setup_cassandra.sh


### PR DESCRIPTION
* Removed `dist: trusty` because trusty is now the default so let's not lock out future dist upgrades.
* Start testing Python 3 in `allow_failures`mode because 2020 is not so far away.
* Run [flake8](http://flake8.pycqa.org) to find Python syntax errors or undefined names
* Run flake8 in --exit-zero mode for other "style violations"