### PR TITLE
scripts/hashdist.py import errno

### DIFF
--- a/scripts/hashdist.py
+++ b/scripts/hashdist.py
@@ -2,6 +2,7 @@
 
 from Queue import Queue
 import argparse
+import errno
 import logging
 import multiprocessing
 import os


### PR DESCRIPTION
Fixes one issue in #1850  `errno.EPIPE`is used on line 86.

https://docs.python.org/2/library/errno.html